### PR TITLE
fix: withdraw rewards amount matching issue

### DIFF
--- a/src/components/msg/utils.tsx
+++ b/src/components/msg/utils.tsx
@@ -638,7 +638,7 @@ export const getMessageByType = (message: any, viewRaw: boolean, t: any) => {
 };
 
 export const convertMsgsToModels = (transaction: any) => {
-  const messages = R.pathOr([], ['messages'], transaction).map((msg) => {
+  const messages = R.pathOr([], ['messages'], transaction).map((msg, index) => {
     const model = getMessageModelByType(msg?.['@type']);
     if (model === MODELS.MsgWithdrawDelegatorReward
       || model === MODELS.MsgWithdrawValidatorCommission
@@ -651,7 +651,7 @@ export const convertMsgsToModels = (transaction: any) => {
         events = transaction.logs[0].events;
       }
 
-      return model.fromJson(msg, events);
+      return model.fromJson(msg, events, index);
     }
     return model.fromJson(msg);
   });

--- a/src/models/msg/distribution/msg_withdraw_validator_commission.ts
+++ b/src/models/msg/distribution/msg_withdraw_validator_commission.ts
@@ -19,7 +19,7 @@ class MsgWithdrawValidatorCommission {
   }
 
   static getWithdrawalAmount(events: any) {
-    if(events === null) {
+    if (events === null) {
       return [formatToken(0)];
     }
     const withdrawEvents = events.filter((x) => x.type === 'withdraw_commission');

--- a/src/models/msg/distribution/msg_withdrawal_delegator_reward.ts
+++ b/src/models/msg/distribution/msg_withdrawal_delegator_reward.ts
@@ -20,12 +20,23 @@ class MsgWithdrawDelegatorReward {
     this.json = payload.json;
   }
 
-  static getWithdrawalAmount(events: any) {
-    if(events === null) {
+  static getWithdrawalAmount(events: any, validatorAddress: string) {
+    if (events === null) {
       return [formatToken(0)];
     }
     const withdrawEvents = events.filter((x) => x.type === 'withdraw_rewards');
-    const withdrawAmounts = R.pathOr([], [0, 'attributes'], withdrawEvents).filter((x) => x.key === 'amount');
+
+    // 해당 validator에 맞는 withdraw_rewards 이벤트 찾기
+    const matchingEvent = withdrawEvents.find((event) => {
+      const validatorAttr = event.attributes?.find((attr) => attr.key === 'validator');
+      return validatorAttr?.value === validatorAddress;
+    });
+
+    if (!matchingEvent) {
+      return [formatToken(0)];
+    }
+
+    const withdrawAmounts = matchingEvent.attributes.filter((x) => x.key === 'amount');
 
     const amounts = R.pathOr('0', [0, 'value'], withdrawAmounts).split(',').map((x) => {
       const [amount, denom = chainConfig.primaryTokenUnit] = x.match(/[a-z]+|[^a-z]+/gi);
@@ -35,14 +46,15 @@ class MsgWithdrawDelegatorReward {
     return amounts;
   }
 
-  static fromJson(json: any, events?: any) {
-    const amounts = this.getWithdrawalAmount(events);
+  static fromJson(json: any, events?: any, msgIndex?: number) {
+    const validatorAddress = json.validator_address;
+    const amounts = this.getWithdrawalAmount(events, validatorAddress);
 
     return new MsgWithdrawDelegatorReward({
       json,
       type: json['@type'],
       delegatorAddress: json.delegator_address,
-      validatorAddress: json.validator_address,
+      validatorAddress,
       amounts,
     });
   }

--- a/src/models/msg/distribution/msg_withdrawal_delegator_reward.ts
+++ b/src/models/msg/distribution/msg_withdrawal_delegator_reward.ts
@@ -26,7 +26,7 @@ class MsgWithdrawDelegatorReward {
     }
     const withdrawEvents = events.filter((x) => x.type === 'withdraw_rewards');
 
-    // 해당 validator에 맞는 withdraw_rewards 이벤트 찾기
+    // Find matching withdraw_rewards event for the specific validator
     const matchingEvent = withdrawEvents.find((event) => {
       const validatorAttr = event.attributes?.find((attr) => attr.key === 'validator');
       return validatorAttr?.value === validatorAddress;
@@ -38,6 +38,7 @@ class MsgWithdrawDelegatorReward {
 
     const withdrawAmounts = matchingEvent.attributes.filter((x) => x.key === 'amount');
 
+    // Parse amount string and format each token (e.g., "123456ufct" -> formatted token)
     const amounts = R.pathOr('0', [0, 'value'], withdrawAmounts).split(',').map((x) => {
       const [amount, denom = chainConfig.primaryTokenUnit] = x.match(/[a-z]+|[^a-z]+/gi);
       return formatToken(amount, denom);
@@ -46,7 +47,7 @@ class MsgWithdrawDelegatorReward {
     return amounts;
   }
 
-  static fromJson(json: any, events?: any, msgIndex?: number) {
+  static fromJson(json: any, events?: any) {
     const validatorAddress = json.validator_address;
     const amounts = this.getWithdrawalAmount(events, validatorAddress);
 


### PR DESCRIPTION
## Problem
In the transaction that withdraws rewards from multiple validators, the same amount was shown for every message.

### **Before:**
   - first validator: 540.777777 FCT
   - second validator: 540.777777 FCT (should have been diff amount)

### **After:**
   - first validator: 540.777777 FCT
   - second validator: 19.4214 FCT

## Changes
Modify scripts (`src/models/msg/distribution/msg_withdrawal_delegator_reward.ts`)