### PR TITLE
feat: add transaction message types

### DIFF
--- a/public/locales/en/message_contents.json
+++ b/public/locales/en/message_contents.json
@@ -72,6 +72,7 @@
   "txTokenUpdateURIContent" : "The {{tokenID}} token URI has been updated",
   "txCosmwasmStoreCodeContent" : "uploaded by <0>{{owner}}</0> [code_id : {{codeId}}]",
   "txCosmwasmInstantiateContractContent" : "InstantiateContract <0>{{contract}}</0> [code_id : {{codeId}}]",
+  "txCosmwasmInstantiateContractContent2" : "InstantiateContract2 <0>{{contract}}</0> [code_id : {{codeId}}]",
   "txCosmwasmExecuteContractContent" : "ExecuteContract <0>{{contract}}</0>",
   "txCosmwasmMigrateContractContent" : "MigrateContract <0>{{contract}}</0> [code_id : {{codeId}}]",
   "txCosmwasmUpdateAdminContent" : "Updated new admin <0>{{newAdmin}}</0> for <1>{{contract}}</1>",

--- a/public/locales/en/message_contents.json
+++ b/public/locales/en/message_contents.json
@@ -3,6 +3,7 @@
   "txDelegateContent": "<0>{{user}}</0> delegated <1>{{amount}}</1> to <2>{{to}}</2>",
   "txRedelegateContent": "<0>{{user}}</0> redelegated <1>{{amount}}</1> from <2>{{from}}</2> to <3>{{to}}</3>",
   "txUndelegateContent": "<0>{{user}}</0> undelegated <1>{{amount}}</1> from <2>{{from}}</2>",
+  "txCancelUndelegateContent": "<0>{{user}}</0> cancelled undelegation of <1>{{amount}}</1> from <2>{{from}}</2>",
   "txCreateValidatorContent": "<0>{{user}}</0> created validator <1>{{validator}}</1>",
   "txEditValidatorContent": "<0>{{validator}}</0> updated their validator details",
   "txSendContent": "<0>{{user}}</0> sent <1>{{amount}}</1> to <2>{{address}}</2>",

--- a/public/locales/en/message_contents.json
+++ b/public/locales/en/message_contents.json
@@ -76,5 +76,6 @@
   "txCosmwasmExecuteContractContent" : "ExecuteContract <0>{{contract}}</0>",
   "txCosmwasmMigrateContractContent" : "MigrateContract <0>{{contract}}</0> [code_id : {{codeId}}]",
   "txCosmwasmUpdateAdminContent" : "Updated new admin <0>{{newAdmin}}</0> for <1>{{contract}}</1>",
-  "txCosmwasmClearAdminContent" : "Clear admin <0>{{contract}}</0>"
+  "txCosmwasmClearAdminContent" : "Clear admin <0>{{contract}}</0>",
+  "txCosmwasmUpdateLabelContent" : "Updated new label <0>{{newLabel}}</0> for <1>{{contract}}</1>"
 }

--- a/public/locales/en/message_labels.json
+++ b/public/locales/en/message_labels.json
@@ -2,6 +2,7 @@
   "txDelegateLabel": "Delegate",
   "txRedelegateLabel": "Redelegate",
   "txUndelegateLabel": "Undelegate",
+  "txCancelUndelegateLabel": "Cancel Undelegate",
   "txCreateValidatorLabel": "Create Validator",
   "txEditValidatorLabel": "Edit Validator",
   "txSendLabel": "Send",

--- a/public/locales/en/message_labels.json
+++ b/public/locales/en/message_labels.json
@@ -75,5 +75,6 @@
   "txCosmwasmExecuteContractLabel" : "CosmWasm ExecuteContract",
   "txCosmwasmMigrateContractLabel" : "CosmWasm MigrateContract",
   "txCosmwasmUpdateAdminLabel" : "CosmWasm UpdateAdmin",
-  "txCosmwasmClearAdminLabel" : "CosmWasm ClearAdmin"
+  "txCosmwasmClearAdminLabel" : "CosmWasm ClearAdmin",
+  "txCosmwasmUpdateLabelLabel" : "CosmWasm UpdateLabel"
 }

--- a/public/locales/en/message_labels.json
+++ b/public/locales/en/message_labels.json
@@ -71,6 +71,7 @@
   "txTokenUpdateURILabel" : "Token Update",
   "txCosmwasmStoreCodeLabel" : "CosmWasm StoreCode",
   "txCosmwasmInstantiateContractLabel" : "CosmWasm InstantiateContract",
+  "txCosmwasmInstantiateContractLabel2" : "CosmWasm InstantiateContract2",
   "txCosmwasmExecuteContractLabel" : "CosmWasm ExecuteContract",
   "txCosmwasmMigrateContractLabel" : "CosmWasm MigrateContract",
   "txCosmwasmUpdateAdminLabel" : "CosmWasm UpdateAdmin",

--- a/src/components/msg/cosmwasm/instantiate_contract2/index.tsx
+++ b/src/components/msg/cosmwasm/instantiate_contract2/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Trans from 'next-translate/Trans';
+import { Typography } from '@material-ui/core';
+import { Name } from '@components';
+import { MsgCosmwasmInstantiateContract2 } from '@models';
+
+const CosmwasmInstantiateContract2 = (props: {
+  message: MsgCosmwasmInstantiateContract2;
+}) => {
+  const { message } = props;
+
+  return (
+    <Typography>
+      <Trans
+        i18nKey="message_contents:txCosmwasmInstantiateContractContent2"
+        components={[
+            (
+              <Name
+                address={message.contractAddress}
+                name={message.contractAddress}
+              />
+            ),
+        ]}
+        values={{
+            codeId: message.codeId,
+        }}
+      />
+    </Typography>
+  );
+};
+
+export default CosmwasmInstantiateContract2;

--- a/src/components/msg/cosmwasm/update_label/index.tsx
+++ b/src/components/msg/cosmwasm/update_label/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Trans from 'next-translate/Trans';
+import { Typography } from '@material-ui/core';
+import { Name } from '@components';
+import { MsgCosmwasmUpdateLabel } from '@models';
+
+const CosmwasmUpdateLabel = (props: {
+  message: MsgCosmwasmUpdateLabel;
+}) => {
+  const { message } = props;
+
+  return (
+    <Typography>
+      <Trans
+        i18nKey="message_contents:txCosmwasmUpdateLabelContent"
+        components={[
+            (
+              <Name
+                address={message.newLabelString}
+                name={message.newLabelString}
+              />
+            ),
+            (
+              <Name
+                address={message.contractAddress}
+                name={message.contractAddress}
+              />
+            ),
+        ]}
+      />
+    </Typography>
+  );
+};
+
+export default CosmwasmUpdateLabel;

--- a/src/components/msg/index.ts
+++ b/src/components/msg/index.ts
@@ -15,6 +15,7 @@ import Delegate from './staking/delegate';
 import Unknown from './unknown';
 import Redelegate from './staking/redelegate';
 import Undelegate from './staking/undelegate';
+import CancelUndelegate from './staking/cancel_undelegate';
 import CreateValidator from './staking/create_validator';
 import EditValidator from './staking/edit_validator';
 import Send from './bank/send';
@@ -103,6 +104,7 @@ export {
   Unknown,
   Redelegate,
   Undelegate,
+  CancelUndelegate,
   CreateValidator,
   EditValidator,
   Send,

--- a/src/components/msg/index.ts
+++ b/src/components/msg/index.ts
@@ -87,6 +87,7 @@ import TokenUpdateURI from './token/updateURI';
 
 import CosmwasmStoreCode from './cosmwasm/storecode';
 import CosmwasmInstantiateContract from './cosmwasm/instantiate_contract';
+import CosmwasmInstantiateContract2 from './cosmwasm/instantiate_contract2';
 import CosmwasmExecuteContract from './cosmwasm/execute_contract';
 import CosmwasmMigrateContract from './cosmwasm/migrate_contract';
 import CosmwasmUpdateAdmin from './cosmwasm/update_admin';
@@ -174,6 +175,7 @@ export {
   TokenUpdateURI,
   CosmwasmStoreCode,
   CosmwasmInstantiateContract,
+  CosmwasmInstantiateContract2,
   CosmwasmExecuteContract,
   CosmwasmMigrateContract,
   CosmwasmUpdateAdmin,

--- a/src/components/msg/index.ts
+++ b/src/components/msg/index.ts
@@ -92,6 +92,7 @@ import CosmwasmExecuteContract from './cosmwasm/execute_contract';
 import CosmwasmMigrateContract from './cosmwasm/migrate_contract';
 import CosmwasmUpdateAdmin from './cosmwasm/update_admin';
 import CosmwasmClearAdmin from './cosmwasm/clear_admin';
+import CosmwasmUpdateLabel from './cosmwasm/update_label';
 
 export {
   getMessageModelByType,
@@ -180,4 +181,5 @@ export {
   CosmwasmMigrateContract,
   CosmwasmUpdateAdmin,
   CosmwasmClearAdmin,
+  CosmwasmUpdateLabel,
 };

--- a/src/components/msg/staking/cancel_undelegate/__snapshots__/inedx.test.tsx.snap
+++ b/src/components/msg/staking/cancel_undelegate/__snapshots__/inedx.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`screen: TransactionDetails/CancelUndelegate matches snapshot 1`] = `
+<p
+  className="MuiTypography-root MuiTypography-body1"
+>
+  message_contents:txCancelUndelegateContent
+</p>
+`;

--- a/src/components/msg/staking/cancel_undelegate/index.test.tsx
+++ b/src/components/msg/staking/cancel_undelegate/index.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import renderer from 'react-test-renderer';
+import { MockTheme } from '@tests/utils';
+import { MsgCancelUndelegate } from '@models';
+import CancelUndelegate from '.';
+
+// ==================================
+// mocks
+// ==================================
+jest.mock('@components', () => ({
+  Name: (props) => <div id="Name" {...props} />,
+}));
+
+// ==================================
+// unit tests
+// ==================================
+describe('screen: TransactionDetails/CancelUndelegate', () => {
+  it('matches snapshot', () => {
+    const message = new MsgCancelUndelegate({
+      category: 'staking',
+      type: 'MsgEditValidator',
+      delegatorAddress: 'delegatorAddress',
+      validatorAddress: 'validatorAddress',
+      amount: {
+        denom: 'udaric',
+        amount: '1000000000',
+      },
+    });
+    const component = renderer.create(
+      <RecoilRoot>
+        <MockTheme>
+          <CancelUndelegate
+            message={message}
+          />
+        </MockTheme>
+      </RecoilRoot>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+});

--- a/src/components/msg/staking/cancel_undelegate/index.tsx
+++ b/src/components/msg/staking/cancel_undelegate/index.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Trans from 'next-translate/Trans';
+import { Typography } from '@material-ui/core';
+import { Name } from '@components';
+import { MsgCancelUndelegate } from '@models';
+import { useProfileRecoil } from '@recoil/profiles';
+import {
+  formatToken, formatNumber,
+} from '@utils/format_token';
+
+const CancelUndelegate = (props: {
+  message: MsgCancelUndelegate;
+}) => {
+  const { message } = props;
+  const amount = formatToken(message.amount.amount, message.amount.denom);
+
+  const parsedAmount = `${formatNumber(amount.value, amount.exponent)} ${amount.displayDenom.toUpperCase()}`;
+
+  const delegator = useProfileRecoil(message.delegatorAddress);
+  const delegatorMoniker = delegator ? delegator?.name : message
+    .delegatorAddress;
+
+  const validator = useProfileRecoil(message.validatorAddress);
+  const validatorMoniker = validator ? validator?.name : message
+    .validatorAddress;
+
+  return (
+    <Typography>
+      <Trans
+        i18nKey="message_contents:txCancelUndelegateContent"
+        components={[
+          (
+            <Name
+              address={message.delegatorAddress}
+              name={delegatorMoniker}
+            />
+          ),
+          <b />,
+          (
+            <Name
+              address={message.validatorAddress}
+              name={validatorMoniker}
+            />
+          ),
+        ]}
+        values={{
+          amount: parsedAmount,
+        }}
+      />
+    </Typography>
+  );
+};
+
+export default CancelUndelegate;

--- a/src/components/msg/utils.tsx
+++ b/src/components/msg/utils.tsx
@@ -588,6 +588,12 @@ const getDataByType = (type: string) => {
       tagTheme: 'nine',
       tagDisplay: 'txCosmwasmClearAdminLabel',
     },
+    '/cosmwasm.wasm.v1.MsgUpdateContractLabel': {
+      model: MODELS.MsgCosmwasmUpdateLabel,
+      content: COMPONENTS.CosmwasmUpdateLabel,
+      tagTheme: 'nine',
+      tagDisplay: 'txCosmwasmUpdateLabelLabel',
+    },
   };
 
   if (defaultTypeToModel[type]) return defaultTypeToModel[type];

--- a/src/components/msg/utils.tsx
+++ b/src/components/msg/utils.tsx
@@ -558,6 +558,12 @@ const getDataByType = (type: string) => {
       tagTheme: 'nine',
       tagDisplay: 'txCosmwasmInstantiateContractLabel',
     },
+    '/cosmwasm.wasm.v1.MsgInstantiateContract2': {
+      model: MODELS.MsgCosmwasmInstantiateContract2,
+      content: COMPONENTS.CosmwasmInstantiateContract2,
+      tagTheme: 'nine',
+      tagDisplay: 'txCosmwasmInstantiateContractLabel2',
+    },
     '/cosmwasm.wasm.v1.MsgExecuteContract': {
       model: MODELS.MsgCosmwasmExecuteContract,
       content: COMPONENTS.CosmwasmExecuteContract,

--- a/src/components/msg/utils.tsx
+++ b/src/components/msg/utils.tsx
@@ -33,6 +33,12 @@ const getDataByType = (type: string) => {
       tagTheme: 'one',
       tagDisplay: 'txUndelegateLabel',
     },
+    '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation': {
+      model: MODELS.MsgCancelUndelegate,
+      content: COMPONENTS.CancelUndelegate,
+      tagTheme: 'one',
+      tagDisplay: 'txCancelUndelegateLabel',
+    },
     '/cosmos.staking.v1beta1.MsgCreateValidator': {
       model: MODELS.MsgCreateValidator,
       content: COMPONENTS.CreateValidator,

--- a/src/components/msg/utils.tsx
+++ b/src/components/msg/utils.tsx
@@ -662,6 +662,7 @@ export const convertMsgsToModels = (transaction: any) => {
       || model === MODELS.MsgWithdrawValidatorCommission
       || model === MODELS.MsgNFTMint
       || model === MODELS.MsgCosmwasmInstantiateContract
+      || model === MODELS.MsgCosmwasmInstantiateContract2
       || model === MODELS.MsgCosmwasmStoreCode) {
       let events = R.pathOr(null, ['events'], transaction);
       const isLegacy = transaction?.logs?.[0]?.events;
@@ -683,9 +684,11 @@ export const convertDefaultRaw = (transaction: any) => {
     if (model === MODELS.MsgCosmwasmClearAdmin
       || model === MODELS.MsgCosmwasmExecuteContract
       || model === MODELS.MsgCosmwasmInstantiateContract
+      || model === MODELS.MsgCosmwasmInstantiateContract2
       || model === MODELS.MsgCosmwasmMigrateContract
       || model === MODELS.MsgCosmwasmStoreCode
-      || model === MODELS.MsgCosmwasmUpdateAdmin) {
+      || model === MODELS.MsgCosmwasmUpdateAdmin
+      || model === MODELS.MsgCosmwasmUpdateLabel) {
       return true;
     }
     return false;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,6 +28,7 @@ import MsgDelegate from './msg/staking/msg_delegate';
 import MsgEditValidator from './msg/staking/msg_edit_validator';
 import MsgRedelegate from './msg/staking/msg_redelegate';
 import MsgUndelegate from './msg/staking/msg_undelegate';
+import MsgCancelUndelegate from './msg/staking/msg_cancel_undelegate';
 import MsgUnknown from './msg/msg_unknown';
 import MsgWithdrawValidatorCommission from './msg/distribution/msg_withdraw_validator_commission';
 import MsgBlockUser from './msg/profiles/msg_block_user';
@@ -119,6 +120,7 @@ export {
   MsgEditValidator,
   MsgRedelegate,
   MsgUndelegate,
+  MsgCancelUndelegate,
   MsgSubmitProposal,
   MsgCancelProposal,
   MsgUnknown,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -86,6 +86,7 @@ import MsgTokenUpdateURI from './msg/token/msg_token_updateURI';
 
 import MsgCosmwasmStoreCode from './msg/cosmwasm/msg_cosmwasm_storecode';
 import MsgCosmwasmInstantiateContract from './msg/cosmwasm/msg_cosmwasm_instantiate_contract';
+import MsgCosmwasmInstantiateContract2 from './msg/cosmwasm/msg_cosmwasm_instantiate_contract2';
 import MsgCosmwasmExecuteContract from './msg/cosmwasm/msg_cosmwasm_execute_contract';
 import MsgCosmwasmMigrateContract from './msg/cosmwasm/msg_cosmwasm_migrate_contract';
 import MsgCosmwasmUpdateAdmin from './msg/cosmwasm/msg_cosmwasm_update_admin';
@@ -178,6 +179,7 @@ export {
   MsgTokenUpdateURI,
   MsgCosmwasmStoreCode,
   MsgCosmwasmInstantiateContract,
+  MsgCosmwasmInstantiateContract2,
   MsgCosmwasmExecuteContract,
   MsgCosmwasmMigrateContract,
   MsgCosmwasmUpdateAdmin,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -91,6 +91,7 @@ import MsgCosmwasmExecuteContract from './msg/cosmwasm/msg_cosmwasm_execute_cont
 import MsgCosmwasmMigrateContract from './msg/cosmwasm/msg_cosmwasm_migrate_contract';
 import MsgCosmwasmUpdateAdmin from './msg/cosmwasm/msg_cosmwasm_update_admin';
 import MsgCosmwasmClearAdmin from './msg/cosmwasm/msg_cosmwasm_clear_admin';
+import MsgCosmwasmUpdateLabel from './msg/cosmwasm/msg_cosmwasm_update_label';
 
 export {
   BigDipperNetwork,
@@ -184,4 +185,5 @@ export {
   MsgCosmwasmMigrateContract,
   MsgCosmwasmUpdateAdmin,
   MsgCosmwasmClearAdmin,
+  MsgCosmwasmUpdateLabel,
 };

--- a/src/models/msg/cosmwasm/msg_cosmwasm_instantiate_contract2.ts
+++ b/src/models/msg/cosmwasm/msg_cosmwasm_instantiate_contract2.ts
@@ -1,0 +1,69 @@
+import { Categories } from '../types';
+
+class MsgCosmwasmInstantiateContract2 {
+    public category: Categories;
+    public type: string;
+    public json: any;
+
+    public ownerAddress: string;
+    public contractAddress: string;
+    public adminAddress: string;
+    public label: string;
+    public codeId: string;
+
+    constructor(payload: any) {
+      this.category = 'nft';
+      this.type = payload.type;
+      this.json = payload.json;
+
+      this.ownerAddress = payload.ownerAddress;
+      this.adminAddress = payload.adminAddress;
+      this.contractAddress = payload.contractAddress;
+      this.label = payload.label;
+      this.codeId = payload.codeId;
+    }
+
+    static getInstantiateCodeId(events: any) {
+      if (events === null) {
+        return 'Unknown';
+      }
+      const WasmEvent = events.find((event) => event.type === 'instantiate'
+        && event.attributes?.some((attr) => attr.key === 'code_id'));
+      const codeIdAttr = WasmEvent?.attributes?.find((attr) => attr.key === 'code_id');
+      const codeId = codeIdAttr?.value || 'Unknown';
+      return codeId;
+    }
+
+    static fromJson(json: any, events: any) {
+      let contractAddress = 'NULL';
+
+      try {
+        if (events !== null && events.length !== 0) {
+          contractAddress = events.filter((v:any) => {
+            return v.type === 'instantiate';
+          })[0].attributes[0].value;
+        }
+        const codeId = this.getInstantiateCodeId(events);
+
+        return new MsgCosmwasmInstantiateContract2({
+          json,
+          type: json['@type'],
+          ownerAddress: json.sender,
+          adminAddress: json.admin,
+          contractAddress,
+          codeId,
+        });
+      } catch (error) {
+        return new MsgCosmwasmInstantiateContract2({
+          json,
+          type: json['@type'],
+          ownerAddress: json.sender,
+          adminAddress: json.admin,
+          contractAddress,
+          codeId: json.code_id,
+        });
+      }
+    }
+}
+
+export default MsgCosmwasmInstantiateContract2;

--- a/src/models/msg/cosmwasm/msg_cosmwasm_update_label.ts
+++ b/src/models/msg/cosmwasm/msg_cosmwasm_update_label.ts
@@ -1,0 +1,33 @@
+import { Categories } from '../types';
+
+class MsgCosmwasmUpdateLabel {
+    public category: Categories;
+    public type: string;
+    public json: any;
+
+    public ownerAddress: string;
+    public newLabelString: string;
+    public contractAddress: string;
+
+    constructor(payload: any) {
+      this.category = 'nft';
+      this.type = payload.type;
+      this.json = payload.json;
+
+      this.ownerAddress = payload.ownerAddress;
+      this.newLabelString = payload.newLabelString;
+      this.contractAddress = payload.contractAddress;
+    }
+
+    static fromJson(json: any) {
+      return new MsgCosmwasmUpdateLabel({
+        json,
+        type: json['@type'],
+        ownerAddress: json.sender,
+        newLabelString: json.new_label,
+        contractAddress: json.contract,
+      });
+    }
+}
+
+export default MsgCosmwasmUpdateLabel;

--- a/src/models/msg/staking/msg_cancel_undelegate.ts
+++ b/src/models/msg/staking/msg_cancel_undelegate.ts
@@ -1,0 +1,35 @@
+import * as R from 'ramda';
+import { Categories } from '../types';
+
+class MsgCancelUndelegate {
+  public category: Categories;
+  public type: string;
+  public delegatorAddress: string;
+  public validatorAddress: string;
+  public amount: MsgCoin;
+  public json: any;
+
+  constructor(payload: any) {
+    this.category = 'staking';
+    this.type = payload.type;
+    this.delegatorAddress = payload.delegatorAddress;
+    this.validatorAddress = payload.validatorAddress;
+    this.amount = payload.amount;
+    this.json = payload.json;
+  }
+
+  static fromJson(json: any) {
+    return new MsgCancelUndelegate({
+      json,
+      type: json['@type'],
+      delegatorAddress: json?.delegator_address,
+      validatorAddress: json?.validator_address,
+      amount: {
+        denom: json?.amount?.denom,
+        amount: R.pathOr('0', ['amount', 'amount'], json),
+      },
+    });
+  }
+}
+
+export default MsgCancelUndelegate;


### PR DESCRIPTION
## Add Transaction Type Label Support

### Overview
Added support for displaying transaction type labels in the explorer interface.

### Changes
- Added `MsgCosmwasmInstantiateContract2` to the message model handling
- Extended transaction type label definitions
- Updated message type mapping for better coverage

### Benefits
- ✅ Better support for CosmWasm v2 transaction types
- ✅ More accurate transaction type labels
- ✅ Improved user experience when viewing transaction details

### Testing
- Verified that `MsgCosmwasmInstantiateContract2` messages are properly displayed
- Confirmed transaction type labels appear correctly in the UI
- Tested with various CosmWasm transaction types

### Screenshots

**Before:**
- Cancel Undelegate
  <img width="1402" height="336" alt="image" src="https://github.com/user-attachments/assets/890dffa4-e26c-40dc-93ba-95b1d6e1b053" />
- Cosmwasm Instantiate2
  <img width="1399" height="266" alt="image" src="https://github.com/user-attachments/assets/97d9384f-1373-4e1b-91be-3199f5e69c65" />
- Cosmwasm Update Label
  <img width="1395" height="261" alt="image" src="https://github.com/user-attachments/assets/25d6b48c-1fb9-4260-bcfa-1cdb2435a3d9" />

**After:**
- Cancel Undelegate
  <img width="1413" height="162" alt="image" src="https://github.com/user-attachments/assets/19be1e4f-f27c-43ac-8bdd-75a9cca33009" />
- Cosmwasm Instantiate2
  <img width="1411" height="162" alt="image" src="https://github.com/user-attachments/assets/b5a8bb7d-44ed-41be-b80f-af18a39399fa" />
- Cosmwasm Update Label
  <img width="1416" height="146" alt="image" src="https://github.com/user-attachments/assets/a865919e-46d1-4316-8204-cebef6533fc5" />


### Related
- Transaction details page improvements
- CosmWasm message type support