### PR TITLE
update: validator list and profile image loading approach

### DIFF
--- a/src/recoil/profiles/hooks.ts
+++ b/src/recoil/profiles/hooks.ts
@@ -1,5 +1,8 @@
 /* eslint-disable max-len */
-import { useEffect } from 'react';
+import {
+  useEffect,
+  useState,
+} from 'react';
 import {
   useRecoilValue,
   useRecoilCallback,
@@ -25,6 +28,31 @@ export const useProfileRecoil = (address: string): AvatarName | null => {
   const delegatorAddress = useRecoilValue(readDelegatorAddress(address));
   const rawProfile = useRecoilValue(readProfileExist(address));
   const profile = useRecoilValue(readProfile(address));
+  const [validatorsIdentityList, setValidatorsIdentityList] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchValidatorsIdentityList = async () => {
+      const validatorsIdentityListUrl = process.env.NEXT_PUBLIC_VALIDATORS_IDENTITY_LIST_URL;
+
+      if (!validatorsIdentityListUrl) {
+        return;
+      }
+
+      try {
+        const response = await fetch(validatorsIdentityListUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to load validators identity list: ${response.status}`);
+        }
+        const data = await response.json();
+        setValidatorsIdentityList(data);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Error fetching validators identity list:', error);
+      }
+    };
+
+    fetchValidatorsIdentityList();
+  }, []);
 
   const fetchProfile = useRecoilCallback(({ set }) => async () => {
     const fetchedProfile = await getProfile(delegatorAddress);
@@ -49,6 +77,24 @@ export const useProfileRecoil = (address: string): AvatarName | null => {
     }
   }, [address]);
 
+  // Apply validator identity list to profile
+  if (!profile) {
+    return profile;
+  }
+
+  if (validatorsIdentityList?.profileInfos) {
+    const profileInfo = validatorsIdentityList.profileInfos.find(
+      (p: any) => p.operatorAddress === address,
+    );
+
+    if (profileInfo?.url) {
+      return {
+        ...profile,
+        imageUrl: profileInfo.url,
+      };
+    }
+  }
+
   return profile;
 };
 
@@ -60,6 +106,31 @@ export const useProfilesRecoil = (addresses: string[]): AvatarName[] => {
   const delegatorAddresses = useRecoilValue(readDelegatorAddresses(addresses));
   const rawProfiles: ProfileAtomState[] = useRecoilValue(readProfilesExist(addresses));
   const profiles = useRecoilValue(readProfiles(addresses));
+  const [validatorsIdentityList, setValidatorsIdentityList] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchValidatorsIdentityList = async () => {
+      const validatorsIdentityListUrl = process.env.NEXT_PUBLIC_VALIDATORS_IDENTITY_LIST_URL;
+
+      if (!validatorsIdentityListUrl) {
+        return;
+      }
+
+      try {
+        const response = await fetch(validatorsIdentityListUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to load validators identity list: ${response.status}`);
+        }
+        const data = await response.json();
+        setValidatorsIdentityList(data);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Error fetching validators identity list:', error);
+      }
+    };
+
+    fetchValidatorsIdentityList();
+  }, []);
 
   const fetchProfiles = useRecoilCallback(({ set }) => async () => {
     const fetchedProfiles = await Promise.all(rawProfiles.map(async (x, i) => {
@@ -88,5 +159,26 @@ export const useProfilesRecoil = (addresses: string[]): AvatarName[] => {
     }
   }, []);
 
-  return profiles;
+  // Apply validator identity list to profiles
+  const profilesWithIdentity = profiles.map((profile, i) => {
+    if (!validatorsIdentityList?.profileInfos) {
+      return profile;
+    }
+
+    const operatorAddress = addresses[i];
+    const profileInfo = validatorsIdentityList.profileInfos.find(
+      (p: any) => p.operatorAddress === operatorAddress,
+    );
+
+    if (profileInfo?.url) {
+      return {
+        ...profile,
+        imageUrl: profileInfo.url,
+      };
+    }
+
+    return profile;
+  });
+
+  return profilesWithIdentity;
 };

--- a/src/screens/validators/components/list/hooks.ts
+++ b/src/screens/validators/components/list/hooks.ts
@@ -37,12 +37,12 @@ export const useValidators = () => {
   // Fetch Data
   // ==========================
   useValidatorsQuery({
-    onCompleted: async(data) => {
-      const state = await formatValidators(data);
-      
+    onCompleted: async (data) => {
+      const formattedState = await formatValidators(data);
+
       handleSetState({
         loading: false,
-        ...state,
+        ...formattedState,
       });
     },
   });
@@ -59,20 +59,24 @@ export const useValidators = () => {
 
     const { signedBlockWindow } = slashingParams;
 
-    let formattedItems: ValidatorType[] = await Promise.all(data.validator.filter((x) => x.validatorInfo).map(async (x) => {
+    const filteredValidators = data.validator.filter((x) => x.validatorInfo);
+    let formattedItems: ValidatorType[] = await Promise.all(filteredValidators.map(async (x) => {
       let votingPower = R.pathOr(0, ['validatorVotingPowers', 0, 'votingPower'], x);
-      votingPower = votingPower / 10**6
+      votingPower /= 10 ** 6;
       const votingPowerPercent = numeral((votingPower / votingPowerOverall) * 100).value();
 
       const missedBlockCounter = R.pathOr(0, ['validatorSigningInfos', 0, 'missedBlocksCounter'], x);
       const condition = getValidatorCondition(signedBlockWindow, missedBlockCounter);
 
       let commission = null;
-      try{
-        const response = await axios.get(`${process.env.NEXT_PUBLIC_REST_CHAIN_URL}/cosmos/staking/v1beta1/validators/${x.validatorInfo.operatorAddress}`)
+      try {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_REST_CHAIN_URL}/cosmos/staking/v1beta1/validators/${x.validatorInfo.operatorAddress}`,
+        );
         const commissionRate = response.data.validator.commission.commission_rates.rate;
         commission = Number(commissionRate) * 100;
-      }catch(error){
+      } catch (error) {
+        // eslint-disable-next-line no-console
         console.log(error);
       }
 


### PR DESCRIPTION
## Summary
Load validator profile images from external identity list.

## Changes
- Fetch identity list from env URL
- Match by operatorAddress
- Apply in recoil/profiles/hooks.ts

## Testing
<img width="1835" height="670" alt="image" src="https://github.com/user-attachments/assets/73a563be-3200-4279-8176-fb7863e637a8" />
