### PR TITLE
fix: treat empty content as TextProposal

### DIFF
--- a/src/screens/proposal_details/utils.ts
+++ b/src/screens/proposal_details/utils.ts
@@ -1,7 +1,7 @@
 export const getProposalType = (proposalType: string) => {
   let type = proposalType;
   if (proposalType === "/cosmos.gov.v1beta1.TextProposal" ||
-    proposalType === "/cosmos.gov.v1.MsgExecLegacyContent") {
+    proposalType === "/cosmos.gov.v1.MsgExecLegacyContent" || proposalType === "") {
     type = "textProposal";
   }
 


### PR DESCRIPTION
## Problem
When `overview.content` is an empty array [], proposal details fail to show the correct type.
- `content` becomes undefined (no first element)
- @type is read as empty string
- getProposalType("") returns "", so the type label is blank

## Solution
Update `getProposalType` to treat empty string as textProposal.
Proposals with empty content are effectively TextProposal in Cosmos governance, so this fallback is appropriate.

## Changes
- File: `src/screens/proposal_details/utils.ts`
- Change: Add `proposalType === ""` to the TextProposal condition in getProposalType
```
if (proposalType === "/cosmos.gov.v1beta1.TextProposal" ||
-   proposalType === "/cosmos.gov.v1.MsgExecLegacyContent") {
+   proposalType === "/cosmos.gov.v1.MsgExecLegacyContent" || proposalType === "") {    
    type = "textProposal";  
}
```

## Testing
- Proposal details with `content: []` now show type "Text Proposal" instead of empty
- Existing proposals with valid `@type` continue to work as before