### PR TITLE
feat: update tx message types and proposal detail overview

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,4 +1,6 @@
 declare module 'react-spring';
+declare module 'classnames';
+declare module 'ramda';
 declare module '*.png';
 declare module '*.jpg';
 declare module '*.jpeg';

--- a/i18n.js
+++ b/i18n.js
@@ -8,7 +8,7 @@ module.exports = {
     'rgx:^/@*': ['profiles', 'accounts'],
     'rgx:^/blocks': ['blocks', 'transactions', 'message_labels', 'message_contents'],
     'rgx:^/transactions': ['transactions', 'message_labels', 'message_contents'],
-    'rgx:^/proposals': ['proposals'],
+    'rgx:^/proposals': ['proposals', 'message_labels'],
     'rgx:^/validators': ['validators', 'transactions', 'accounts', 'message_labels', 'message_contents', 'message_labels'],
     'rgx:^/accounts': ['accounts', 'transactions', 'validators', 'message_labels', 'message_contents', 'message_labels'],
     'rgx:^/params': ['params'],

--- a/public/locales/en/proposals.json
+++ b/public/locales/en/proposals.json
@@ -54,7 +54,7 @@
   "send": "Send",
   "recipients": "Recipients",
   "multiple": "Multiple",
-  "msgExec": "Msg Exec",
+  "authzExec": "Authz Exec",
   "other": "Other",
   "messages": "Messages",
   "authority": "Authority"

--- a/src/components/msg/tag_map.ts
+++ b/src/components/msg/tag_map.ts
@@ -1,0 +1,104 @@
+/**
+ * Lightweight @type → { tagDisplay, tagTheme } mapping.
+ * Mirrors the tagDisplay / tagTheme values in msg/utils.tsx defaultTypeToModel + customTypeToModel,
+ * but without importing MODELS or COMPONENTS so it can be used in lightweight contexts.
+ */
+
+type TagInfo = { tagDisplay: string; tagTheme: TagTheme };
+
+const TAG_MAP: Record<string, TagInfo> = {
+  // staking
+  '/cosmos.staking.v1beta1.MsgDelegate': { tagTheme: 'one', tagDisplay: 'txDelegateLabel' },
+  '/cosmos.staking.v1beta1.MsgBeginRedelegate': { tagTheme: 'one', tagDisplay: 'txRedelegateLabel' },
+  '/cosmos.staking.v1beta1.MsgUndelegate': { tagTheme: 'one', tagDisplay: 'txUndelegateLabel' },
+  '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation': { tagTheme: 'one', tagDisplay: 'txCancelUndelegateLabel' },
+  '/cosmos.staking.v1beta1.MsgCreateValidator': { tagTheme: 'one', tagDisplay: 'txCreateValidatorLabel' },
+  '/cosmos.staking.v1beta1.MsgEditValidator': { tagTheme: 'one', tagDisplay: 'txEditValidatorLabel' },
+  // bank
+  '/cosmos.bank.v1beta1.MsgSend': { tagTheme: 'two', tagDisplay: 'txSendLabel' },
+  '/cosmos.bank.v1beta1.MsgMultiSend': { tagTheme: 'two', tagDisplay: 'txMultisendLabel' },
+  // crisis
+  '/cosmos.crisis.v1beta1.MsgVerifyInvariant': { tagTheme: 'three', tagDisplay: 'txVerifyInvariantLabel' },
+  // slashing
+  '/cosmos.slashing.v1beta1.MsgUnjail': { tagTheme: 'five', tagDisplay: 'txUnjailLabel' },
+  // distribution
+  '/cosmos.distribution.v1beta1.MsgFundCommunityPool': { tagTheme: 'six', tagDisplay: 'txFundLabel' },
+  '/cosmos.distribution.v1beta1.MsgSetWithdrawAddress': { tagTheme: 'six', tagDisplay: 'txsetRewardAddressLabel' },
+  '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward': { tagTheme: 'six', tagDisplay: 'txWithdrawRewardLabel' },
+  '/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission': { tagTheme: 'six', tagDisplay: 'txWithdrawCommissionLabel' },
+  // governance
+  '/cosmos.gov.v1beta1.MsgDeposit': { tagTheme: 'seven', tagDisplay: 'txDepositLabel' },
+  '/cosmos.gov.v1.MsgDeposit': { tagTheme: 'seven', tagDisplay: 'txDepositLabel' },
+  '/cosmos.gov.v1beta1.MsgVote': { tagTheme: 'seven', tagDisplay: 'txVoteLabel' },
+  '/cosmos.gov.v1.MsgVote': { tagTheme: 'seven', tagDisplay: 'txVoteLabel' },
+  '/cosmos.gov.v1beta1.MsgSubmitProposal': { tagTheme: 'seven', tagDisplay: 'txSubmitProposalLabel' },
+  '/cosmos.gov.v1.MsgSubmitProposal': { tagTheme: 'seven', tagDisplay: 'txSubmitProposalLabel' },
+  '/cosmos.gov.v1.MsgCancelProposal': { tagTheme: 'seven', tagDisplay: 'txCancelProposalLabel' },
+  // ibc client
+  '/ibc.core.client.v1.MsgCreateClient': { tagTheme: 'nine', tagDisplay: 'txCreateClientLabel' },
+  '/ibc.core.client.v1.MsgUpdateClient': { tagTheme: 'nine', tagDisplay: 'txUpdateClientLabel' },
+  '/ibc.core.client.v1.MsgUpgradeClient': { tagTheme: 'nine', tagDisplay: 'txUpgradeClientLabel' },
+  '/ibc.core.client.v1.MsgSubmitMisbehaviour': { tagTheme: 'nine', tagDisplay: 'txSubmitMisbehaviourLabel' },
+  // ibc channel
+  '/ibc.core.channel.v1.MsgRecvPacket': { tagTheme: 'nine', tagDisplay: 'txRecvPacketLabel' },
+  '/ibc.core.channel.v1.MsgAcknowledgement': { tagTheme: 'nine', tagDisplay: 'txAcknowledgementLabel' },
+  '/ibc.core.channel.v1.MsgChannelCloseConfirm': { tagTheme: 'nine', tagDisplay: 'txChannelCloseConfirmLabel' },
+  '/ibc.core.channel.v1.MsgChannelCloseInit': { tagTheme: 'nine', tagDisplay: 'txChannelCloseInitLabel' },
+  '/ibc.core.channel.v1.MsgChannelOpenAck': { tagTheme: 'nine', tagDisplay: 'txChannelOpenAckLabel' },
+  '/ibc.core.channel.v1.MsgChannelOpenConfirm': { tagTheme: 'nine', tagDisplay: 'txChannelOpenConfirmLabel' },
+  '/ibc.core.channel.v1.MsgChannelOpenInit': { tagTheme: 'nine', tagDisplay: 'txChannelOpenInitLabel' },
+  '/ibc.core.channel.v1.MsgChannelOpenTry': { tagTheme: 'nine', tagDisplay: 'txChannelOpenTryLabel' },
+  '/ibc.core.channel.v1.MsgTimeout': { tagTheme: 'nine', tagDisplay: 'txTimeoutLabel' },
+  '/ibc.core.channel.v1.MsgTimeoutOnClose': { tagTheme: 'nine', tagDisplay: 'txTimeoutOnCloseLabel' },
+  // ibc connection
+  '/ibc.core.connection.v1.MsgConnectionOpenAck': { tagTheme: 'nine', tagDisplay: 'txConnectionOpenAckLabel' },
+  '/ibc.core.connection.v1.MsgConnectionOpenConfirm': { tagTheme: 'nine', tagDisplay: 'txConnectionOpenConfirmLabel' },
+  '/ibc.core.connection.v1.MsgConnectionOpenInit': { tagTheme: 'nine', tagDisplay: 'txConnectionOpenInitLabel' },
+  '/ibc.core.connection.v1.MsgConnectionOpenTry': { tagTheme: 'nine', tagDisplay: 'txConnectionOpenTryLabel' },
+  // ibc transfer
+  '/ibc.applications.transfer.v1.MsgTransfer': { tagTheme: 'ten', tagDisplay: 'txTransferLabel' },
+  // authz
+  '/cosmos.authz.v1beta1.MsgGrant': { tagTheme: 'thirteen', tagDisplay: 'MsgGrant' },
+  '/cosmos.authz.v1beta1.MsgRevoke': { tagTheme: 'thirteen', tagDisplay: 'MsgRevoke' },
+  '/cosmos.authz.v1beta1.MsgExec': { tagTheme: 'thirteen', tagDisplay: 'MsgExec' },
+  // feegrant
+  '/cosmos.feegrant.v1beta1.MsgGrantAllowance': { tagTheme: 'fourteen', tagDisplay: 'MsgGrantAllowance' },
+  '/cosmos.feegrant.v1beta1.MsgRevokeAllowance': { tagTheme: 'fourteen', tagDisplay: 'MsgRevokeAllowance' },
+  // vesting
+  '/cosmos.vesting.v1beta1.MsgCreateVestingAccount': { tagTheme: 'fifteen', tagDisplay: 'MsgCreateVestingAccount' },
+  '/cosmos.vesting.v1beta1.MsgCreatePeriodicVestingAccount': { tagTheme: 'fifteen', tagDisplay: 'MsgCreatePeriodicVestingAccount' },
+  // firmachain nft
+  '/firmachain.firmachain.nft.MsgMint': { tagTheme: 'four', tagDisplay: 'txNFTMintLabel' },
+  '/firmachain.nft.MsgMint': { tagTheme: 'four', tagDisplay: 'txNFTMintLabel' },
+  '/firmachain.firmachain.nft.MsgTransfer': { tagTheme: 'four', tagDisplay: 'txNFTTransferLabel' },
+  '/firmachain.nft.MsgTransfer': { tagTheme: 'four', tagDisplay: 'txNFTTransferLabel' },
+  '/firmachain.firmachain.nft.MsgBurn': { tagTheme: 'four', tagDisplay: 'txNFTBurnLabel' },
+  '/firmachain.nft.MsgBurn': { tagTheme: 'four', tagDisplay: 'txNFTBurnLabel' },
+  // firmachain contract
+  '/firmachain.firmachain.contract.MsgAddContractLog': { tagTheme: 'four', tagDisplay: 'txAddContractLogLabel' },
+  '/firmachain.contract.MsgAddContractLog': { tagTheme: 'four', tagDisplay: 'txAddContractLogLabel' },
+  '/firmachain.firmachain.contract.MsgCreateContractFile': { tagTheme: 'four', tagDisplay: 'txCreateContractFileLabel' },
+  '/firmachain.contract.MsgCreateContractFile': { tagTheme: 'four', tagDisplay: 'txCreateContractFileLabel' },
+  // firmachain token
+  '/firmachain.firmachain.token.MsgCreateToken': { tagTheme: 'two', tagDisplay: 'txTokenCreateLabel' },
+  '/firmachain.token.MsgCreateToken': { tagTheme: 'two', tagDisplay: 'txTokenCreateLabel' },
+  '/firmachain.firmachain.token.MsgMint': { tagTheme: 'two', tagDisplay: 'txTokenMintLabel' },
+  '/firmachain.token.MsgMint': { tagTheme: 'two', tagDisplay: 'txTokenMintLabel' },
+  '/firmachain.firmachain.token.MsgBurn': { tagTheme: 'four', tagDisplay: 'txTokenBurnLabel' },
+  '/firmachain.token.MsgBurn': { tagTheme: 'four', tagDisplay: 'txTokenBurnLabel' },
+  '/firmachain.firmachain.token.MsgUpdateTokenURI': { tagTheme: 'three', tagDisplay: 'txTokenUpdateURILabel' },
+  '/firmachain.token.MsgUpdateTokenURI': { tagTheme: 'three', tagDisplay: 'txTokenUpdateURILabel' },
+  // cosmwasm
+  '/cosmwasm.wasm.v1.MsgStoreCode': { tagTheme: 'nine', tagDisplay: 'txCosmwasmStoreCodeLabel' },
+  '/cosmwasm.wasm.v1.MsgInstantiateContract': { tagTheme: 'nine', tagDisplay: 'txCosmwasmInstantiateContractLabel' },
+  '/cosmwasm.wasm.v1.MsgInstantiateContract2': { tagTheme: 'nine', tagDisplay: 'txCosmwasmInstantiateContractLabel2' },
+  '/cosmwasm.wasm.v1.MsgExecuteContract': { tagTheme: 'nine', tagDisplay: 'txCosmwasmExecuteContractLabel' },
+  '/cosmwasm.wasm.v1.MsgMigrateContract': { tagTheme: 'nine', tagDisplay: 'txCosmwasmMigrateContractLabel' },
+  '/cosmwasm.wasm.v1.MsgUpdateAdmin': { tagTheme: 'nine', tagDisplay: 'txCosmwasmUpdateAdminLabel' },
+  '/cosmwasm.wasm.v1.MsgClearAdmin': { tagTheme: 'nine', tagDisplay: 'txCosmwasmClearAdminLabel' },
+  '/cosmwasm.wasm.v1.MsgUpdateContractLabel': { tagTheme: 'nine', tagDisplay: 'txCosmwasmUpdateLabelLabel' },
+};
+
+const DEFAULT_TAG_INFO: TagInfo = { tagDisplay: 'txUnknownLabel', tagTheme: 'zero' };
+
+export const getTagInfoByType = (type: string): TagInfo => TAG_MAP[type] ?? DEFAULT_TAG_INFO;

--- a/src/screens/proposal_details/components/overview/components/collapsible_message_item.tsx
+++ b/src/screens/proposal_details/components/overview/components/collapsible_message_item.tsx
@@ -6,6 +6,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { Tag } from '@components';
 import { KNOWN_GOV_TYPES } from '../constants';
 import type { OverviewDisplayType } from '../utils';
+import { getExecNestedTypeSummary } from '../utils';
 import MessageBodyContent from './message_body_content';
 import type { OverviewType } from '../../../types';
 
@@ -25,10 +26,14 @@ const CollapsibleMessageItem: React.FC<Props> = ({
   classes,
 }) => {
   const { t } = useTranslation('proposals');
+  const tMsg = useTranslation('message_labels').t;
   const isGov = (KNOWN_GOV_TYPES as readonly string[]).includes(displayType);
   const single = items.length === 1;
+  const isMsgExec = displayType === 'authzExec';
+
+  const nestedSummary = isMsgExec ? getExecNestedTypeSummary(items) : [];
+
   const label = single ? t(displayType) : `${t(displayType)} (${items.length})`;
-  const tagTheme = displayType === 'msgExec' ? 'thirteen' : 'seven';
 
   return (
     <div className={classes.messageSection}>
@@ -44,9 +49,42 @@ const CollapsibleMessageItem: React.FC<Props> = ({
           }
         }}
       >
-        {isGov ? (
-          <Tag value={label} theme={tagTheme} className={classes.messagePillTag} />
-        ) : (
+        {isMsgExec && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              flexWrap: 'wrap',
+            }}
+          >
+            <Tag
+              value={t('authzExec')}
+              theme="thirteen"
+              className={classes.messagePillTag}
+            />
+            {nestedSummary.map(({
+              typeStr,
+              tagDisplay,
+              tagTheme,
+              count,
+            }) => {
+              const displayLabel = tMsg(tagDisplay);
+              return (
+                <Tag
+                  key={typeStr}
+                  value={count > 1 ? `${displayLabel} (${count})` : displayLabel}
+                  theme={tagTheme as TagTheme}
+                  className={classes.messagePillTag}
+                />
+              );
+            })}
+          </div>
+        )}
+        {!isMsgExec && isGov && (
+          <Tag value={label} theme="seven" className={classes.messagePillTag} />
+        )}
+        {!isMsgExec && !isGov && (
           <span className={classes.messagePill}>{label}</span>
         )}
         <ExpandMoreIcon

--- a/src/screens/proposal_details/components/overview/components/collapsible_message_item.tsx
+++ b/src/screens/proposal_details/components/overview/components/collapsible_message_item.tsx
@@ -1,16 +1,16 @@
-import React from "react";
-import classnames from "classnames";
-import { Collapse } from "@material-ui/core";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import useTranslation from "next-translate/useTranslation";
-import { Tag } from "@components";
-import { KNOWN_GOV_TYPES } from "../constants";
-import type { OverviewDisplayType } from "../utils";
-import MessageBodyContent from "./message_body_content";
-import type { OverviewType } from "../../../types";
+import React from 'react';
+import classnames from 'classnames';
+import { Collapse } from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import useTranslation from 'next-translate/useTranslation';
+import { Tag } from '@components';
+import { KNOWN_GOV_TYPES } from '../constants';
+import type { OverviewDisplayType } from '../utils';
+import MessageBodyContent from './message_body_content';
+import type { OverviewType } from '../../../types';
 
 type Props = {
-  items: OverviewType["content"][number][];
+  items: OverviewType['content'][number][];
   displayType: OverviewDisplayType;
   isOpen: boolean;
   onToggle: () => void;
@@ -24,11 +24,11 @@ const CollapsibleMessageItem: React.FC<Props> = ({
   onToggle,
   classes,
 }) => {
-  const { t } = useTranslation("proposals");
+  const { t } = useTranslation('proposals');
   const isGov = (KNOWN_GOV_TYPES as readonly string[]).includes(displayType);
   const single = items.length === 1;
   const label = single ? t(displayType) : `${t(displayType)} (${items.length})`;
-  const tagTheme = displayType === "msgExec" ? "thirteen" : "seven";
+  const tagTheme = displayType === 'msgExec' ? 'thirteen' : 'seven';
 
   return (
     <div className={classes.messageSection}>
@@ -38,7 +38,7 @@ const CollapsibleMessageItem: React.FC<Props> = ({
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
+          if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             onToggle();
           }

--- a/src/screens/proposal_details/components/overview/components/message_body_content.tsx
+++ b/src/screens/proposal_details/components/overview/components/message_body_content.tsx
@@ -1,50 +1,61 @@
-import React from "react";
-import classnames from "classnames";
-import * as R from "ramda";
-import { Typography } from "@material-ui/core";
-import { Table, TableBody, TableCell, TableHead, TableRow } from "@material-ui/core";
-import useTranslation from "next-translate/useTranslation";
-import { Name, Tag } from "@components";
-import { useProfilesRecoil } from "@recoil/profiles";
-import { formatNumber, formatTokenByExponent } from "@src/utils/format_token";
-import CommunityPoolSpend from "./community_pool_spend";
-import ParamsChange from "./params_change";
-import SoftwareUpgrade from "./software_upgrade";
-import { getProposalType } from "../../../utils";
-import { isCommunityPoolSpendItem, hasParams, isMsgExecItem, getExecSendRecipients } from "../utils";
-import type { OverviewType } from "../../../types";
-import type { MsgUpdateParamsContent } from "../../../types";
-import ParamsChangeV5 from "./params_change_v5";
+import React from 'react';
+import classnames from 'classnames';
+import * as R from 'ramda';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@material-ui/core';
+import useTranslation from 'next-translate/useTranslation';
+import {
+  Name, Tag,
+} from '@components';
+import { useProfilesRecoil } from '@recoil/profiles';
+import {
+  formatNumber, formatTokenByExponent,
+} from '@src/utils/format_token';
+import { getProposalType } from '../../../utils';
+import {
+  isCommunityPoolSpendItem, hasParams, isMsgExecItem, getExecSendRecipients,
+} from '../utils';
+import type {
+  OverviewType, MsgUpdateParamsContent,
+} from '../../../types';
+import ParamsChangeV5 from './params_change_v5';
+import CommunityPoolSpend from './community_pool_spend';
+import ParamsChange from './params_change';
+import SoftwareUpgrade from './software_upgrade';
 
 type ParamChangeRow = { subspace: string; key: string; value: string };
 
-const getChanges = (content: OverviewType["content"][number]): ParamChangeRow[] =>
-  R.pathOr([], ["changes"], content) as ParamChangeRow[];
+const getChanges = (content: OverviewType['content'][number]): ParamChangeRow[] => R.pathOr([], 'changes', content) as ParamChangeRow[];
 
 type Props =
-  | { content: OverviewType["content"][number]; items?: undefined; classes?: Record<string, string> }
-  | { content?: undefined; items: OverviewType["content"][number][]; classes?: Record<string, string> };
+  | { content: OverviewType['content'][number]; items?: undefined; classes?: Record<string, string> }
+  | { content?: undefined; items: OverviewType['content'][number][]; classes?: Record<string, string> };
 
 function ParamsChangeBlock({
   content,
-  classes = {},
+  classes,
 }: {
-  content: OverviewType["content"][number];
-  classes?: Record<string, string>;
+  content: OverviewType['content'][number];
+  classes: Record<string, string>;
 }) {
-  const { t } = useTranslation("proposals");
+  const { t } = useTranslation('proposals');
   const changes = getChanges(content);
   return (
     <div className={classes.labelValueRow}>
-      <Typography variant="body1" className={classnames("label", classes.labelValueRowLabel)}>
-        {t("changes")}
+      <Typography variant="body1" className={classnames('label', classes.labelValueRowLabel)}>
+        {t('changes')}
       </Typography>
       <div>
-        {changes.length > 0 ? (
-          <ParamsChange changes={changes} />
-        ) : hasParams(content) ? (
+        {changes.length > 0 && <ParamsChange changes={changes} />}
+        {changes.length === 0 && hasParams(content) && (
           <ParamsChangeV5 content={content as MsgUpdateParamsContent} />
-        ) : null}
+        )}
       </div>
     </div>
   );
@@ -52,21 +63,21 @@ function ParamsChangeBlock({
 
 function SoftwareUpgradeBlock({
   content,
-  classes = {},
+  classes,
 }: {
-  content: OverviewType["content"][number];
-  classes?: Record<string, string>;
+  content: OverviewType['content'][number];
+  classes: Record<string, string>;
 }) {
-  const { t } = useTranslation("proposals");
+  const { t } = useTranslation('proposals');
   return (
     <div className={classes.labelValueRow}>
-      <Typography variant="body1" className={classnames("label", classes.labelValueRowLabel)}>
-        {t("plan")}
+      <Typography variant="body1" className={classnames('label', classes.labelValueRowLabel)}>
+        {t('plan')}
       </Typography>
       <SoftwareUpgrade
-        height={R.pathOr("0", ["plan", "height"], content)}
-        info={R.pathOr("", ["plan", "info"], content)}
-        name={R.pathOr("", ["plan", "name"], content)}
+        height={R.pathOr('0', ['plan', 'height'], content)}
+        info={R.pathOr('', ['plan', 'info'], content)}
+        name={R.pathOr('', ['plan', 'name'], content)}
       />
     </div>
   );
@@ -85,13 +96,13 @@ function ExecSendTable({
   const profiles = useProfilesRecoil(addresses);
 
   return (
-    <div style={{ overflow: "auto" }}>
-      <Table style={{ tableLayout: "fixed" }}>
+    <div style={{ overflow: 'auto' }}>
+      <Table style={{ tableLayout: 'fixed' }}>
         <TableHead>
           <TableRow>
-            <TableCell style={{ width: "35%" }}>{t("fromAddress")}</TableCell>
-            <TableCell style={{ width: "35%" }}>{t("toAddress")}</TableCell>
-            <TableCell style={{ width: "30%" }}>{t("amount")}</TableCell>
+            <TableCell style={{ width: '35%' }}>{t('fromAddress')}</TableCell>
+            <TableCell style={{ width: '35%' }}>{t('toAddress')}</TableCell>
+            <TableCell style={{ width: '30%' }}>{t('amount')}</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -103,13 +114,13 @@ function ExecSendTable({
             const amountStr = formatNumber(formatTokenByExponent(row.amount, 6));
             return (
               <TableRow key={`${row.fromAddress}-${row.toAddress}-${i}`}>
-                <TableCell style={{ width: "35%" }}>
+                <TableCell style={{ width: '35%' }}>
                   <Name name={fromName} address={row.fromAddress} />
                 </TableCell>
-                <TableCell style={{ width: "35%" }}>
+                <TableCell style={{ width: '35%' }}>
                   <Name name={toName} address={row.toAddress} />
                 </TableCell>
-                <TableCell style={{ width: "30%" }}>{`${amountStr} FCT`}</TableCell>
+                <TableCell style={{ width: '30%' }}>{`${amountStr} FCT`}</TableCell>
               </TableRow>
             );
           })}
@@ -120,25 +131,28 @@ function ExecSendTable({
 }
 
 const MessageBodyContent: React.FC<Props> = (props) => {
-  const { t } = useTranslation("proposals");
+  const { t } = useTranslation('proposals');
   const items = props.items ?? (props.content ? [props.content] : []);
   const firstItem = items[0];
   const contentType = firstItem
-    ? getProposalType((R.pathOr("", ["@type"], firstItem) as string))
-    : "";
+    ? getProposalType((R.pathOr('', ['@type'], firstItem) as string))
+    : '';
 
   if (items.length === 0) return null;
 
   if (firstItem && isCommunityPoolSpendItem(firstItem)) {
     const recipients = items
       .filter(isCommunityPoolSpendItem)
-      .map((c) => ({ address: c.recipient, amount: c.amount[0]?.amount ?? "0" }));
+      .map((c) => ({
+        address: c.recipient,
+        amount: c.amount[0]?.amount ?? '0',
+      }));
     return <CommunityPoolSpend recipients={recipients} />;
   }
 
   const classes = props.classes ?? {};
 
-  if (contentType === "parameterChangeProposal") {
+  if (contentType === 'parameterChangeProposal') {
     return (
       <>
         {items.map((content, idx) => (
@@ -148,7 +162,7 @@ const MessageBodyContent: React.FC<Props> = (props) => {
     );
   }
 
-  if (contentType === "softwareUpgradeProposal") {
+  if (contentType === 'softwareUpgradeProposal') {
     return (
       <>
         {items.map((content, idx) => (
@@ -158,11 +172,10 @@ const MessageBodyContent: React.FC<Props> = (props) => {
     );
   }
 
-  // MsgExec (authz): render nested MsgSend as table (From / To / Amount), Send label on left (same pill as Msg Exec)
   if (items.some(isMsgExecItem)) {
     const rows = getExecSendRecipients(items);
     if (rows.length > 0) {
-      const sendLabel = rows.length > 1 ? `${t("send")} (${rows.length})` : t("send");
+      const sendLabel = rows.length > 1 ? `${t('send')} (${rows.length})` : t('send');
       return (
         <div className={classes.labelValueRow}>
           <Tag

--- a/src/screens/proposal_details/components/overview/components/message_body_content.tsx
+++ b/src/screens/proposal_details/components/overview/components/message_body_content.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classnames from 'classnames';
 import * as R from 'ramda';
 import {
   Table,
@@ -9,9 +8,8 @@ import {
   TableRow,
   Typography,
 } from '@material-ui/core';
-import useTranslation from 'next-translate/useTranslation';
 import {
-  Name, Tag,
+  Markdown, Name,
 } from '@components';
 import { useProfilesRecoil } from '@recoil/profiles';
 import {
@@ -31,7 +29,7 @@ import SoftwareUpgrade from './software_upgrade';
 
 type ParamChangeRow = { subspace: string; key: string; value: string };
 
-const getChanges = (content: OverviewType['content'][number]): ParamChangeRow[] => R.pathOr([], 'changes', content) as ParamChangeRow[];
+const getChanges = (content: OverviewType['content'][number]): ParamChangeRow[] => R.pathOr([], ['changes'], content) as ParamChangeRow[];
 
 type Props =
   | { content: OverviewType['content'][number]; items?: undefined; classes?: Record<string, string> }
@@ -44,19 +42,41 @@ function ParamsChangeBlock({
   content: OverviewType['content'][number];
   classes: Record<string, string>;
 }) {
-  const { t } = useTranslation('proposals');
+  console.log('------------------------------------------------------');
+  console.log(content);
+  console.log('------------------------------------------------------');
   const changes = getChanges(content);
+  console.log('------------------------------------------------------');
+  console.log(changes);
+  console.log('------------------------------------------------------');
   return (
-    <div className={classes.labelValueRow}>
-      <Typography variant="body1" className={classnames('label', classes.labelValueRowLabel)}>
-        {t('changes')}
-      </Typography>
-      <div>
-        {changes.length > 0 && <ParamsChange changes={changes} />}
-        {changes.length === 0 && hasParams(content) && (
-          <ParamsChangeV5 content={content as MsgUpdateParamsContent} />
-        )}
-      </div>
+    <div className={classes.messageBodyBlock ?? ''}>
+      {changes.length > 0 && <ParamsChange changes={changes} />}
+      {changes.length === 0 && hasParams(content) && (
+        <ParamsChangeV5 content={content as MsgUpdateParamsContent} />
+      )}
+    </div>
+  );
+}
+
+function TextProposalBlock({
+  content,
+  classes,
+}: {
+  content: OverviewType['content'][number];
+  classes: Record<string, string>;
+}) {
+  const title = R.pathOr('', ['title'], content) as string;
+  const description = R.pathOr('', ['description'], content) as string;
+  if (!title && !description) return null;
+  return (
+    <div className={classes.messageBodyBlockCompact ?? ''}>
+      {title && (
+        <Typography variant="body1" component="h3" style={{ marginBottom: 8 }}>
+          {title}
+        </Typography>
+      )}
+      {description && <Markdown markdown={description} />}
     </div>
   );
 }
@@ -68,12 +88,8 @@ function SoftwareUpgradeBlock({
   content: OverviewType['content'][number];
   classes: Record<string, string>;
 }) {
-  const { t } = useTranslation('proposals');
   return (
-    <div className={classes.labelValueRow}>
-      <Typography variant="body1" className={classnames('label', classes.labelValueRowLabel)}>
-        {t('plan')}
-      </Typography>
+    <div className={classes.messageBodyBlockCompact ?? ''}>
       <SoftwareUpgrade
         height={R.pathOr('0', ['plan', 'height'], content)}
         info={R.pathOr('', ['plan', 'info'], content)}
@@ -87,22 +103,29 @@ type ExecSendRow = { fromAddress: string; toAddress: string; amount: string };
 
 function ExecSendTable({
   rows,
-  t,
+  tableWrapClassName,
 }: {
   rows: ExecSendRow[];
-  t: (key: string) => string;
+  tableWrapClassName: string;
 }) {
   const addresses = rows.flatMap((r) => [r.fromAddress, r.toAddress]);
   const profiles = useProfilesRecoil(addresses);
 
   return (
-    <div style={{ overflow: 'auto' }}>
-      <Table style={{ tableLayout: 'fixed' }}>
+    <div className={tableWrapClassName} style={{ overflowX: 'auto' }}>
+      <Table
+        style={{
+          tableLayout: 'fixed',
+          width: '100%',
+          minWidth: 360,
+          minHeight: 100,
+        }}
+      >
         <TableHead>
           <TableRow>
-            <TableCell style={{ width: '35%' }}>{t('fromAddress')}</TableCell>
-            <TableCell style={{ width: '35%' }}>{t('toAddress')}</TableCell>
-            <TableCell style={{ width: '30%' }}>{t('amount')}</TableCell>
+            <TableCell style={{ width: '35%' }}>From Address</TableCell>
+            <TableCell style={{ width: '35%' }}>To Address</TableCell>
+            <TableCell style={{ width: '30%' }}>Amount</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -131,7 +154,6 @@ function ExecSendTable({
 }
 
 const MessageBodyContent: React.FC<Props> = (props) => {
-  const { t } = useTranslation('proposals');
   const items = props.items ?? (props.content ? [props.content] : []);
   const firstItem = items[0];
   const contentType = firstItem
@@ -140,6 +162,8 @@ const MessageBodyContent: React.FC<Props> = (props) => {
 
   if (items.length === 0) return null;
 
+  const classes = props.classes ?? {};
+
   if (firstItem && isCommunityPoolSpendItem(firstItem)) {
     const recipients = items
       .filter(isCommunityPoolSpendItem)
@@ -147,10 +171,12 @@ const MessageBodyContent: React.FC<Props> = (props) => {
         address: c.recipient,
         amount: c.amount[0]?.amount ?? '0',
       }));
-    return <CommunityPoolSpend recipients={recipients} />;
+    return (
+      <div className={classes.messageBodyContentCell ?? ''}>
+        <CommunityPoolSpend recipients={recipients} />
+      </div>
+    );
   }
-
-  const classes = props.classes ?? {};
 
   if (contentType === 'parameterChangeProposal') {
     return (
@@ -172,18 +198,22 @@ const MessageBodyContent: React.FC<Props> = (props) => {
     );
   }
 
+  if (contentType === 'textProposal') {
+    return (
+      <>
+        {items.map((content, idx) => (
+          <TextProposalBlock key={idx} content={content} classes={classes} />
+        ))}
+      </>
+    );
+  }
+
   if (items.some(isMsgExecItem)) {
     const rows = getExecSendRecipients(items);
     if (rows.length > 0) {
-      const sendLabel = rows.length > 1 ? `${t('send')} (${rows.length})` : t('send');
       return (
-        <div className={classes.labelValueRow}>
-          <Tag
-            value={sendLabel}
-            theme="two"
-            className={classnames(classes.labelValueRowLabel, classes.messagePillTag)}
-          />
-          <ExecSendTable rows={rows} t={t} />
+        <div className={classes.messageBodyContentCell ?? ''}>
+          <ExecSendTable rows={rows} tableWrapClassName={classes.messageBodyTableWrap ?? ''} />
         </div>
       );
     }

--- a/src/screens/proposal_details/components/overview/components/messages_section.tsx
+++ b/src/screens/proposal_details/components/overview/components/messages_section.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { Typography } from "@material-ui/core";
-import useTranslation from "next-translate/useTranslation";
-import CollapsibleMessageItem from "./collapsible_message_item";
-import type { MessageGroup } from "../utils";
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import useTranslation from 'next-translate/useTranslation';
+import CollapsibleMessageItem from './collapsible_message_item';
+import type { MessageGroup } from '../utils';
 
 type Props = {
   messageGroups: MessageGroup[];
@@ -11,13 +11,18 @@ type Props = {
   classes: Record<string, string>;
 };
 
-const MessagesSection: React.FC<Props> = ({ messageGroups, openStates, toggleOpen, classes }) => {
-  const { t } = useTranslation("proposals");
+const MessagesSection: React.FC<Props> = ({
+  messageGroups,
+  openStates,
+  toggleOpen,
+  classes,
+}) => {
+  const { t } = useTranslation('proposals');
 
   return (
     <div className={classes.content}>
-      <Typography variant="body1" className="label">
-        {t("messages")}
+      <Typography variant="body1" className={classes.label}>
+        {t('messages')}
       </Typography>
       <div className={classes.messageList}>
         {messageGroups.map((group, groupIndex) => (

--- a/src/screens/proposal_details/components/overview/components/messages_section.tsx
+++ b/src/screens/proposal_details/components/overview/components/messages_section.tsx
@@ -21,7 +21,7 @@ const MessagesSection: React.FC<Props> = ({
 
   return (
     <div className={classes.content}>
-      <Typography variant="body1" className={classes.label}>
+      <Typography variant="body1" className="label">
         {t('messages')}
       </Typography>
       <div className={classes.messageList}>

--- a/src/screens/proposal_details/components/overview/components/metadata_section.tsx
+++ b/src/screens/proposal_details/components/overview/components/metadata_section.tsx
@@ -1,13 +1,15 @@
-import React from "react";
-import dayjs, { formatDayJs } from "@utils/dayjs";
-import useTranslation from "next-translate/useTranslation";
-import { useRecoilValue } from "recoil";
-import { readDate } from "@recoil/settings";
-import { Typography } from "@material-ui/core";
-import { Markdown, Name } from "@components";
-import { useProfileRecoil } from "@recoil/profiles";
-import type { OverviewType } from "../../../types";
-import type { OverviewDisplayType } from "../utils";
+import React from 'react';
+import dayjs, { formatDayJs } from '@utils/dayjs';
+import useTranslation from 'next-translate/useTranslation';
+import { useRecoilValue } from 'recoil';
+import { readDate } from '@recoil/settings';
+import { Typography } from '@material-ui/core';
+import {
+  Markdown, Name,
+} from '@components';
+import { useProfileRecoil } from '@recoil/profiles';
+import type { OverviewType } from '../../../types';
+import type { OverviewDisplayType } from '../utils';
 
 type Props = {
   overview: OverviewType;
@@ -15,15 +17,19 @@ type Props = {
   classes: Record<string, string>;
 };
 
-const DATE_FIELDS: { key: "submitTime" | "depositEndTime" | "votingStartTime" | "votingEndTime" }[] = [
-  { key: "submitTime" },
-  { key: "depositEndTime" },
-  { key: "votingStartTime" },
-  { key: "votingEndTime" },
+const DATE_FIELDS: { key: 'submitTime' | 'depositEndTime' | 'votingStartTime' | 'votingEndTime' }[] = [
+  { key: 'submitTime' },
+  { key: 'depositEndTime' },
+  { key: 'votingStartTime' },
+  { key: 'votingEndTime' },
 ];
 
-const MetadataSection: React.FC<Props> = ({ overview, overviewType, classes }) => {
-  const { t } = useTranslation("proposals");
+const MetadataSection: React.FC<Props> = ({
+  overview,
+  overviewType,
+  classes,
+}) => {
+  const { t } = useTranslation('proposals');
   const dateFormat = useRecoilValue(readDate);
   const proposer = useProfileRecoil(overview.proposer);
   const proposerMoniker = proposer?.name ?? overview.proposer;
@@ -31,30 +37,29 @@ const MetadataSection: React.FC<Props> = ({ overview, overviewType, classes }) =
   return (
     <div className={classes.content}>
       <Typography variant="body1" className="label">
-        {t("type")}
+        {t('type')}
       </Typography>
       <Typography variant="body1" className="value">
         {t(overviewType)}
       </Typography>
       <Typography variant="body1" className="label">
-        {t("proposer")}
+        {t('proposer')}
       </Typography>
       <Name name={proposerMoniker} address={proposer.address} />
       {DATE_FIELDS.map(
-        ({ key }) =>
-          overview[key] && (
-            <React.Fragment key={key}>
-              <Typography variant="body1" className="label">
-                {t(key)}
-              </Typography>
-              <Typography variant="body1" className="value">
-                {formatDayJs(dayjs.utc(overview[key]), dateFormat)}
-              </Typography>
-            </React.Fragment>
-          )
+        ({ key }) => overview[key] && (
+          <React.Fragment key={key}>
+            <Typography variant="body1" className="label">
+              {t(key)}
+            </Typography>
+            <Typography variant="body1" className="value">
+              {formatDayJs(dayjs.utc(overview[key]), dateFormat)}
+            </Typography>
+          </React.Fragment>
+        ),
       )}
       <Typography variant="body1" className="label">
-        {t("description")}
+        {t('description')}
       </Typography>
       <Markdown markdown={overview.description} />
     </div>

--- a/src/screens/proposal_details/components/overview/components/params_change/index.tsx
+++ b/src/screens/proposal_details/components/overview/components/params_change/index.tsx
@@ -19,28 +19,35 @@ const ParamsChange: React.FC<{
   changes,
 }) => {
   const { t } = useTranslation('proposals');
-  const colWidth = { first: '20%', second: '35%', third: '45%' };
+  const colWidth = {
+    first: '20%',
+    second: '35%',
+    third: '45%',
+  };
   return (
-    <div style={{ overflow: 'auto' }}>
-      <Table style={{ tableLayout: 'fixed' }}>
-        <TableHead>
-          <TableRow>
-            <TableCell style={{ width: colWidth.first }}>{t('subspace')}</TableCell>
-            <TableCell style={{ width: colWidth.second }}>{t('key')}</TableCell>
-            <TableCell style={{ width: colWidth.third }}>{t('value')}</TableCell>
+    <Table
+      style={{
+        tableLayout: 'fixed',
+        width: '100%',
+      }}
+    >
+      <TableHead>
+        <TableRow>
+          <TableCell style={{ width: colWidth.first }}>{t('subspace')}</TableCell>
+          <TableCell style={{ width: colWidth.second }}>{t('key')}</TableCell>
+          <TableCell style={{ width: colWidth.third }}>{t('value')}</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {changes.map((row) => (
+          <TableRow key={row.key}>
+            <TableCell style={{ width: colWidth.first }}>{row.subspace}</TableCell>
+            <TableCell style={{ width: colWidth.second }}>{row.key}</TableCell>
+            <TableCell style={{ width: colWidth.third }}>{row.value}</TableCell>
           </TableRow>
-        </TableHead>
-        <TableBody>
-          {changes.map((row) => (
-            <TableRow key={row.key}>
-              <TableCell style={{ width: colWidth.first }}>{row.subspace}</TableCell>
-              <TableCell style={{ width: colWidth.second }}>{row.key}</TableCell>
-              <TableCell style={{ width: colWidth.third }}>{row.value}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+        ))}
+      </TableBody>
+    </Table>
   );
 };
 

--- a/src/screens/proposal_details/components/overview/components/params_change_v5/index.tsx
+++ b/src/screens/proposal_details/components/overview/components/params_change_v5/index.tsx
@@ -24,35 +24,45 @@ const ParamsChangeV5: React.FC<{
   const moduleName = extractModuleName(content['@type']);
   const paramsEntries = Object.entries(content.params);
 
-  const colWidth = { first: '20%', second: '35%', third: '45%' };
+  const colWidth = {
+    first: '20%',
+    second: '35%',
+    third: '45%',
+  };
   return (
-    <div style={{ overflow: 'auto' }}>
-      <Table style={{ tableLayout: 'fixed' }}>
-        <TableHead>
-          <TableRow>
-            <TableCell style={{ width: colWidth.first }}>{t('subspace')}</TableCell>
-            <TableCell style={{ width: colWidth.second }}>{t('key')}</TableCell>
-            <TableCell style={{ width: colWidth.third }}>{t('value')}</TableCell>
+    <Table
+      style={{
+        tableLayout: 'fixed',
+        width: '100%',
+      }}
+    >
+      <TableHead>
+        <TableRow>
+          <TableCell style={{ width: colWidth.first }}>{t('subspace')}</TableCell>
+          <TableCell style={{ width: colWidth.second }}>{t('key')}</TableCell>
+          <TableCell style={{ width: colWidth.third }}>{t('value')}</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {paramsEntries.map(([key, value], index) => (
+          <TableRow key={key}>
+            {index === 0 ? (
+              <TableCell
+                rowSpan={paramsEntries.length}
+                style={{
+                  verticalAlign: 'top',
+                  width: colWidth.first,
+                }}
+              >
+                {moduleName}
+              </TableCell>
+            ) : null}
+            <TableCell style={{ width: colWidth.second }}>{key}</TableCell>
+            <TableCell style={{ width: colWidth.third }}>{safeToString(value)}</TableCell>
           </TableRow>
-        </TableHead>
-        <TableBody>
-          {paramsEntries.map(([key, value], index) => (
-            <TableRow key={key}>
-              {index === 0 ? (
-                <TableCell
-                  rowSpan={paramsEntries.length}
-                  style={{ verticalAlign: 'top', width: colWidth.first }}
-                >
-                  {moduleName}
-                </TableCell>
-              ) : null}
-              <TableCell style={{ width: colWidth.second }}>{key}</TableCell>
-              <TableCell style={{ width: colWidth.third }}>{safeToString(value)}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+        ))}
+      </TableBody>
+    </Table>
   );
 };
 

--- a/src/screens/proposal_details/components/overview/constants.ts
+++ b/src/screens/proposal_details/components/overview/constants.ts
@@ -1,12 +1,12 @@
 /** Gov proposal types + MsgExec, Other – use Tag theme "seven" for consistent display */
 export const KNOWN_GOV_TYPES = [
-  "textProposal",
-  "parameterChangeProposal",
-  "softwareUpgradeProposal",
-  "communityPoolSpendProposal",
-  "multiple",
-  "msgExec",
-  "other",
+  'textProposal',
+  'parameterChangeProposal',
+  'softwareUpgradeProposal',
+  'communityPoolSpendProposal',
+  'multiple',
+  'msgExec',
+  'other',
 ] as const;
 
 export type KnownGovType = (typeof KNOWN_GOV_TYPES)[number];

--- a/src/screens/proposal_details/components/overview/constants.ts
+++ b/src/screens/proposal_details/components/overview/constants.ts
@@ -5,7 +5,7 @@ export const KNOWN_GOV_TYPES = [
   'softwareUpgradeProposal',
   'communityPoolSpendProposal',
   'multiple',
-  'msgExec',
+  'authzExec',
   'other',
 ] as const;
 

--- a/src/screens/proposal_details/components/overview/hooks/use_overview_state.ts
+++ b/src/screens/proposal_details/components/overview/hooks/use_overview_state.ts
@@ -10,13 +10,10 @@ import {
 } from '../utils';
 
 export const useOverviewState = (overview: OverviewType) => {
-  const contentArray = toContentArray(overview.content as OverviewType['content'] | string);
-  const messageItems = contentArray.filter(
-    (c): c is OverviewType['content'][number] => typeof c === 'object' && c !== null,
-  ) as OverviewType['content'][number][];
+  const messageItems = toContentArray(overview.content as OverviewType['content'] | string);
   const messageGroups = getMessageGroups(messageItems);
-  const hasMessageContent = messageItems.length > 0;
   const overviewType = getOverviewDisplayType(messageItems);
+  const hasMessageContent = messageItems.length > 0 && overviewType !== 'textProposal';
 
   const [openStates, setOpenStates] = useState<Record<number, boolean>>({});
   const toggleOpen = useCallback((groupIndex: number) => {

--- a/src/screens/proposal_details/components/overview/hooks/use_overview_state.ts
+++ b/src/screens/proposal_details/components/overview/hooks/use_overview_state.ts
@@ -1,18 +1,29 @@
-import { useState, useCallback } from "react";
-import type { OverviewType } from "../../../types";
-import { toContentArray, getOverviewDisplayType, getMessageGroups } from "../utils";
-export function useOverviewState(overview: OverviewType) {
-  const contentArray = toContentArray(overview.content as OverviewType["content"] | string);
+import {
+  useCallback,
+  useState,
+} from 'react';
+import type { OverviewType } from '../../../types';
+import {
+  toContentArray,
+  getOverviewDisplayType,
+  getMessageGroups,
+} from '../utils';
+
+export const useOverviewState = (overview: OverviewType) => {
+  const contentArray = toContentArray(overview.content as OverviewType['content'] | string);
   const messageItems = contentArray.filter(
-    (c): c is OverviewType["content"][number] => typeof c === "object" && c !== null
-  ) as OverviewType["content"][number][];
+    (c): c is OverviewType['content'][number] => typeof c === 'object' && c !== null,
+  ) as OverviewType['content'][number][];
   const messageGroups = getMessageGroups(messageItems);
   const hasMessageContent = messageItems.length > 0;
   const overviewType = getOverviewDisplayType(messageItems);
 
   const [openStates, setOpenStates] = useState<Record<number, boolean>>({});
   const toggleOpen = useCallback((groupIndex: number) => {
-    setOpenStates((prev) => ({ ...prev, [groupIndex]: !prev[groupIndex] }));
+    setOpenStates((prev) => ({
+      ...prev,
+      [groupIndex]: !prev[groupIndex],
+    }));
   }, []);
 
   return {
@@ -22,4 +33,4 @@ export function useOverviewState(overview: OverviewType) {
     openStates,
     toggleOpen,
   };
-}
+};

--- a/src/screens/proposal_details/components/overview/index.test.tsx
+++ b/src/screens/proposal_details/components/overview/index.test.tsx
@@ -36,15 +36,16 @@ describe('screen: BlockDetails/Overview', () => {
         <MockTheme>
           <Overview
             overview={{
-              content : [{
+              content: [{
                 '@type': '/cosmos.distribution.v1beta1.MsgCommunityPoolSpend',
-                authority: 'authority',
-                recipient: 'recipient',
-                amount: [{
-                  denom: 'denom',
-                  amount: '1000000',
-                }]
-              }],
+                  authority: 'authority',
+                  recipient: 'recipient',
+                  amount: [{
+                    denom: 'denom',
+                    amount: '1000000',
+                  }],
+                },
+              ],
               metadata: 'metadata',
               proposer: '',
               title: 'title',
@@ -82,13 +83,19 @@ describe('screen: BlockDetails/Overview', () => {
           '@type': '/cosmos.distribution.v1beta1.MsgCommunityPoolSpend',
           authority: 'firma10d07y265gmmuvt4z0w9aw880jnsr700j53mj8f',
           recipient: 'address1',
-          amount: [{ denom: 'ufct', amount: '15000000000' }],
+          amount: [{
+            denom: 'ufct',
+            amount: '15000000000',
+          }],
         },
         {
           '@type': '/cosmos.distribution.v1beta1.MsgCommunityPoolSpend',
           authority: 'firma10d07y265gmmuvt4z0w9aw880jnsr700j53mj8f',
           recipient: 'address2',
-          amount: [{ denom: 'ufct', amount: '25000000000' }],
+          amount: [{
+            denom: 'ufct',
+            amount: '25000000000',
+          }],
         },
         {
           '@type': '/cosmos.gov.v1.MsgUpdateParams',
@@ -96,7 +103,10 @@ describe('screen: BlockDetails/Overview', () => {
           params: {
             quorum: '0.334',
             threshold: '0.5',
-            min_deposit: [{ denom: 'ufct', amount: '5000000000' }],
+            min_deposit: [{
+              denom: 'ufct',
+              amount: '5000000000',
+            }],
             voting_period: '300s',
           },
         },
@@ -104,7 +114,10 @@ describe('screen: BlockDetails/Overview', () => {
           '@type': '/cosmos.distribution.v1beta1.MsgCommunityPoolSpend',
           authority: 'firma10d07y265gmmuvt4z0w9aw880jnsr700j53mj8f',
           recipient: 'address3',
-          amount: [{ denom: 'ufct', amount: '10000000000' }],
+          amount: [{
+            denom: 'ufct',
+            amount: '10000000000',
+          }],
         },
       ],
       metadata: '',

--- a/src/screens/proposal_details/components/overview/index.tsx
+++ b/src/screens/proposal_details/components/overview/index.tsx
@@ -1,13 +1,16 @@
-import React from "react";
-import numeral from "numeral";
-import classnames from "classnames";
-import { Divider } from "@material-ui/core";
-import { SingleProposal, Box } from "@components";
-import MetadataSection from "./components/metadata_section";
-import MessagesSection from "./components/messages_section";
-import { useStyles } from "./styles";
-import { useOverviewState } from "./hooks/use_overview_state";
-import type { OverviewType } from "../../types";
+import React from 'react';
+import numeral from 'numeral';
+import classnames from 'classnames';
+import { Divider } from '@material-ui/core';
+import {
+  SingleProposal,
+  Box,
+} from '@components';
+import MetadataSection from './components/metadata_section';
+import MessagesSection from './components/messages_section';
+import { useStyles } from './styles';
+import { useOverviewState } from './hooks/use_overview_state';
+import type { OverviewType } from '../../types';
 
 const Overview: React.FC<{ overview: OverviewType } & ComponentDefault> = ({
   className,
@@ -25,7 +28,7 @@ const Overview: React.FC<{ overview: OverviewType } & ComponentDefault> = ({
   return (
     <Box className={classnames(className, classes.root)}>
       <SingleProposal
-        id={`#${numeral(overview.id).format("0,0")}`}
+        id={`#${numeral(overview.id).format('0,0')}`}
         title={overview.title}
         status={overview.status}
       />

--- a/src/screens/proposal_details/components/overview/styles.ts
+++ b/src/screens/proposal_details/components/overview/styles.ts
@@ -38,7 +38,9 @@ export const useStyles = () => {
           justifyContent: 'space-between',
           padding: theme.spacing(2),
           cursor: 'pointer',
-          backgroundColor: theme.palette.custom?.general?.surfaceTwo ?? theme.palette.background.paper,
+          backgroundColor: theme.palette.custom?.general?.surfaceTwo
+            ? theme.palette.custom.general.surfaceTwo
+            : theme.palette.background.paper,
           '&:hover': {
             backgroundColor: theme.palette.action.hover,
           },

--- a/src/screens/proposal_details/components/overview/styles.ts
+++ b/src/screens/proposal_details/components/overview/styles.ts
@@ -84,6 +84,25 @@ export const useStyles = () => {
         labelValueRowLabel: {
           transform: `translateX(${theme.spacing(2)}px) translateY(${theme.spacing(1.5)}px)`,
         },
+        messageBodyTableWrap: {
+          width: '100%',
+          minWidth: 0,
+          overflowX: 'auto',
+        },
+        messageBodyContentCell: {
+          width: '100%',
+          minWidth: 0,
+          minHeight: 100,
+        },
+        messageBodyBlock: {
+          width: '100%',
+          minWidth: 0,
+          minHeight: 100,
+        },
+        messageBodyBlockCompact: {
+          width: '100%',
+          minWidth: 0,
+        },
       });
     },
   )();

--- a/src/screens/proposal_details/components/overview/utils.ts
+++ b/src/screens/proposal_details/components/overview/utils.ts
@@ -1,98 +1,124 @@
-import * as R from "ramda";
-import { getProposalType } from "../../utils";
-import type { OverviewType } from "../../types";
-import type { MsgCommunityPoolSpendContent, MsgUpdateParamsContent } from "../../types";
-import { KNOWN_GOV_TYPES } from "./constants";
+import * as R from 'ramda';
+import { getProposalType } from '../../utils';
+import type {
+  MsgCommunityPoolSpendContent,
+  MsgUpdateParamsContent,
+  OverviewType,
+} from '../../types';
+
+import { KNOWN_GOV_TYPES } from './constants';
 
 /** Normalize overview.content (API may return [] or ''; hooks may pass '' when missing) */
 export const toContentArray = (
-  raw: OverviewType["content"] | string
-): (OverviewType["content"][number] | string)[] =>
-  Array.isArray(raw) ? raw : [raw];
+  raw: OverviewType['content'] | string,
+): (
+  OverviewType['content'][number] | string
+)[] => {
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  return [raw];
+};
 
-export const hasParams = (c: unknown): c is MsgUpdateParamsContent =>
-  typeof c === "object" && c !== null && "params" in c;
-
-export const isCommunityPoolSpendItem = (c: unknown): c is MsgCommunityPoolSpendContent =>
-  typeof c === "object" && c !== null && "recipient" in c && "amount" in c;
+export const hasParams = (c: unknown): c is MsgUpdateParamsContent => typeof c === 'object' && c !== null && 'params' in c;
+export const isCommunityPoolSpendItem = (c: unknown): c is MsgCommunityPoolSpendContent => typeof c === 'object' && c !== null && 'recipient' in c && 'amount' in c;
 
 /** MsgExec (authz) with nested msgs */
-export const isMsgExecItem = (c: unknown): c is { "@type": string; msgs?: unknown[] } =>
-  typeof c === "object" &&
-  c !== null &&
-  "msgs" in c &&
-  Array.isArray((c as { msgs?: unknown[] }).msgs);
+export const isMsgExecItem = (c: unknown): c is { '@type': string; msgs?: unknown[] } => {
+  const withMsgs = c as { msgs?: unknown[] };
+  return (
+    typeof c === 'object'
+    && c !== null
+    && 'msgs' in c
+    && Array.isArray(withMsgs.msgs)
+  );
+};
 
-/** From MsgExec.msgs, collect MsgSend rows as { fromAddress, toAddress, amount } for table display */
+/** From MsgExec.msgs, collect MsgSend rows as { fromAddress, toAddress, amount } for table */
+const msgToRow = (
+  msg: unknown,
+): { fromAddress: string; toAddress: string; amount: string } | null => {
+  const m = msg as Record<string, unknown>;
+  if (typeof m !== 'object' || m === null) return null;
+  const type = (m['@type'] as string) ?? '';
+  if (!type.endsWith('.MsgSend')) return null;
+  const toAddress = (m.to_address as string) ?? '';
+  if (!toAddress) return null;
+  const fromAddress = (m.from_address as string) ?? '';
+  const amountArr = (m.amount as { amount?: string }[]) ?? [];
+  const amount = amountArr[0]?.amount ?? '0';
+  return {
+    fromAddress,
+    toAddress,
+    amount,
+  };
+};
+
 export const getExecSendRecipients = (
-  items: OverviewType["content"][number][]
+  items: OverviewType['content'][number][],
 ): { fromAddress: string; toAddress: string; amount: string }[] => {
-  const rows: { fromAddress: string; toAddress: string; amount: string }[] = [];
-  for (const item of items) {
-    if (!isMsgExecItem(item)) continue;
-    const msgs = (item as { msgs?: unknown[] }).msgs ?? [];
-    for (const msg of msgs) {
-      const m = msg as Record<string, unknown>;
-      if (typeof m !== "object" || m === null) continue;
-      const type = (m["@type"] as string) ?? "";
-      if (!type.endsWith(".MsgSend")) continue;
-      const fromAddress = (m.from_address as string) ?? "";
-      const toAddress = (m.to_address as string) ?? "";
-      const amountArr = (m.amount as { amount?: string }[]) ?? [];
-      const amount = amountArr[0]?.amount ?? "0";
-      if (toAddress) rows.push({ fromAddress, toAddress, amount });
-    }
-  }
-  return rows;
+  return items
+    .filter(isMsgExecItem)
+    .flatMap((item) => (item as { msgs?: unknown[] }).msgs ?? [])
+    .map(msgToRow)
+    .filter((row): row is {
+      fromAddress: string;
+      toAddress: string;
+      amount: string;
+    } => row !== null);
 };
 
 export type OverviewDisplayType =
-  | "textProposal"
-  | "parameterChangeProposal"
-  | "softwareUpgradeProposal"
-  | "communityPoolSpendProposal"
-  | "multiple"
-  | "msgExec"
-  | "other";
+  | 'textProposal'
+  | 'parameterChangeProposal'
+  | 'softwareUpgradeProposal'
+  | 'communityPoolSpendProposal'
+  | 'multiple'
+  | 'msgExec'
+  | 'other';
 
 /**
  * Single display type for overview header: "multiple" when >1 message or mixed types.
  */
 export const getOverviewDisplayType = (
-  messageItems: OverviewType["content"][number][]
+  messageItems: OverviewType['content'][number][],
 ): OverviewDisplayType => {
-  if (messageItems.length === 0) return "textProposal";
-  const contentTypes = messageItems.map((c) =>
-    getProposalType(R.pathOr("", ["@type"], c) as string)
-  );
+  if (messageItems.length === 0) return 'textProposal';
+  const contentTypes = messageItems.map((c) => getProposalType(R.pathOr('', ['@type'], c) as string));
   const uniqueTypes = [...new Set(contentTypes.filter(Boolean))];
-  if (messageItems.length > 1 || uniqueTypes.length > 1) return "multiple";
+  if (messageItems.length > 1 || uniqueTypes.length > 1) return 'multiple';
   const first = uniqueTypes[0];
-  return (KNOWN_GOV_TYPES as readonly string[]).includes(first) ? (first as OverviewDisplayType) : "other";
+  return (KNOWN_GOV_TYPES as readonly string[]).includes(first) ? (first as OverviewDisplayType) : 'other';
 };
 
 export const getMessageDisplayType = (
-  content: OverviewType["content"][number]
+  content: OverviewType['content'][number],
 ): OverviewDisplayType => {
-  const typeLabel = getProposalType(R.pathOr("", ["@type"], content) as string);
-  return (KNOWN_GOV_TYPES as readonly string[]).includes(typeLabel) ? (typeLabel as OverviewDisplayType) : "other";
+  const typeLabel = getProposalType(R.pathOr('', ['@type'], content) as string);
+  return (KNOWN_GOV_TYPES as readonly string[]).includes(typeLabel) ? (typeLabel as OverviewDisplayType) : 'other';
 };
 
 export type MessageGroup = {
   displayType: OverviewDisplayType;
-  items: OverviewType["content"][number][];
+  items: OverviewType['content'][number][];
 };
 
 /** Group messages by same type (one section + table when duplicates) */
 export const getMessageGroups = (
-  messageItems: OverviewType["content"][number][]
+  messageItems: OverviewType['content'][number][],
 ): MessageGroup[] => {
-  const byType = new Map<OverviewDisplayType, OverviewType["content"][number][]>();
-  for (const item of messageItems) {
-    const type = getMessageDisplayType(item);
-    const list = byType.get(type) ?? [];
-    list.push(item);
-    byType.set(type, list);
-  }
-  return [...byType.entries()].map(([displayType, items]) => ({ displayType, items }));
+  const byType = messageItems.reduce(
+    (acc, item) => {
+      const type = getMessageDisplayType(item);
+      const list = acc.get(type) ?? [];
+      list.push(item);
+      acc.set(type, list);
+      return acc;
+    },
+    new Map<OverviewDisplayType, OverviewType['content'][number][]>(),
+  );
+  return [...byType.entries()].map(([displayType, items]) => ({
+    displayType,
+    items,
+  }));
 };

--- a/src/screens/proposal_details/components/overview/utils.ts
+++ b/src/screens/proposal_details/components/overview/utils.ts
@@ -1,5 +1,7 @@
 import * as R from 'ramda';
+import { getTagInfoByType } from '@src/components/msg/tag_map';
 import { getProposalType } from '../../utils';
+
 import type {
   MsgCommunityPoolSpendContent,
   MsgUpdateParamsContent,
@@ -8,16 +10,43 @@ import type {
 
 import { KNOWN_GOV_TYPES } from './constants';
 
-/** Normalize overview.content (API may return [] or ''; hooks may pass '' when missing) */
-export const toContentArray = (
-  raw: OverviewType['content'] | string,
-): (
-  OverviewType['content'][number] | string
-)[] => {
-  if (Array.isArray(raw)) {
-    return raw;
+/** Parse JSON string to object or array; returns null on failure */
+function safeParseJson(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
   }
-  return [raw];
+}
+
+/** Normalize overview.content: [] | '' | JSON string | single object → content object array */
+export const toContentArray = (
+  raw: OverviewType['content'] | string | unknown,
+): OverviewType['content'][number][] => {
+  if (raw === null || raw === undefined || raw === '') {
+    return [];
+  }
+  if (typeof raw === 'string') {
+    const parsed = safeParseJson(raw);
+    if (parsed === null) return [];
+    if (Array.isArray(parsed)) {
+      return parsed.filter((c): c is OverviewType['content'][number] => typeof c === 'object' && c !== null);
+    }
+    return [parsed as OverviewType['content'][number]];
+  }
+  if (Array.isArray(raw)) {
+    const expanded = raw.flatMap((item) => {
+      if (typeof item === 'string') {
+        const parsed = safeParseJson(item);
+        if (parsed === null) return [];
+        if (Array.isArray(parsed)) return parsed;
+        return [parsed];
+      }
+      return item !== null && typeof item === 'object' ? [item] : [];
+    });
+    return expanded as OverviewType['content'][number][];
+  }
+  return [raw as OverviewType['content'][number]];
 };
 
 export const hasParams = (c: unknown): c is MsgUpdateParamsContent => typeof c === 'object' && c !== null && 'params' in c;
@@ -74,7 +103,7 @@ export type OverviewDisplayType =
   | 'softwareUpgradeProposal'
   | 'communityPoolSpendProposal'
   | 'multiple'
-  | 'msgExec'
+  | 'authzExec'
   | 'other';
 
 /**
@@ -96,6 +125,39 @@ export const getMessageDisplayType = (
 ): OverviewDisplayType => {
   const typeLabel = getProposalType(R.pathOr('', ['@type'], content) as string);
   return (KNOWN_GOV_TYPES as readonly string[]).includes(typeLabel) ? (typeLabel as OverviewDisplayType) : 'other';
+};
+
+export type NestedMsgSummary = {
+  typeStr: string;
+  tagDisplay: string;
+  tagTheme: string;
+  count: number;
+};
+
+/** Extract nested msg type summaries from MsgExec items with tag info from the global mapping */
+export const getExecNestedTypeSummary = (
+  items: OverviewType['content'][number][],
+): NestedMsgSummary[] => {
+  const msgs = items
+    .filter(isMsgExecItem)
+    .flatMap((item) => (item as { msgs?: unknown[] }).msgs ?? []);
+  const grouped = new Map<string, { tagDisplay: string; tagTheme: string; count: number }>();
+  msgs.forEach((msg) => {
+    const m = msg as Record<string, unknown>;
+    const typeStr = (m?.['@type'] as string) ?? '';
+    if (!grouped.has(typeStr)) {
+      const info = getTagInfoByType(typeStr);
+      grouped.set(typeStr, {
+        ...info,
+        count: 0,
+      });
+    }
+    grouped.get(typeStr)!.count += 1;
+  });
+  return [...grouped.entries()].map(([typeStr, data]) => ({
+    typeStr,
+    ...data,
+  }));
 };
 
 export type MessageGroup = {

--- a/src/screens/proposal_details/hooks.tsx
+++ b/src/screens/proposal_details/hooks.tsx
@@ -7,22 +7,19 @@ import {
   useProposalDetailsQuery,
   ProposalDetailsQuery,
 } from '@graphql/types';
-import { ContentType, ProposalState } from './types';
+import {
+  ProposalState,
+} from './types';
 
 export const useProposalDetails = () => {
   const router = useRouter();
-  const defaultContent: ContentType = {
-    '@type': '',
-    authority: '',
-    plan: null,
-  };
 
   const [state, setState] = useState<ProposalState>({
     loading: true,
     exists: true,
     overview: {
       proposer: '',
-      content: [defaultContent],
+      content: [],
       title: '',
       id: 0,
       description: '',
@@ -36,7 +33,11 @@ export const useProposalDetails = () => {
   });
 
   const handleSetState = (stateChange: any) => {
-    setState((prevState) => R.mergeDeepLeft(stateChange, prevState));
+    setState((prevState) => ({
+      ...prevState,
+      ...stateChange,
+      overview: stateChange.overview != null ? stateChange.overview : prevState.overview,
+    }));
   };
 
   // ==========================
@@ -77,7 +78,7 @@ export const useProposalDetails = () => {
 
       const overview = {
         proposer: R.pathOr('', ['proposal', 0, 'proposer'], data),
-        content: R.pathOr('', ['proposal', 0, 'content'], data),
+        content: R.pathOr([], ['proposal', 0, 'content'], data),
         title: R.pathOr('', ['proposal', 0, 'title'], data),
         id: R.pathOr('', ['proposal', 0, 'proposalId'], data),
         description: R.pathOr('', ['proposal', 0, 'description'], data).replace(/\n\n/gi, '\n\n&nbsp;&nbsp;\n\n'),
@@ -86,6 +87,7 @@ export const useProposalDetails = () => {
         depositEndTime: R.pathOr('', ['proposal', 0, 'depositEndTime'], data),
         votingStartTime,
         votingEndTime,
+        metadata: R.pathOr('', ['proposal', 0, 'metadata'], data),
       };
 
       return overview;

--- a/src/screens/proposal_details/utils.ts
+++ b/src/screens/proposal_details/utils.ts
@@ -1,46 +1,45 @@
-import * as R from "ramda";
+import * as R from 'ramda';
 
 export const getProposalType = (proposalType: string) => {
   let type = proposalType;
-  if (proposalType === "/cosmos.gov.v1beta1.TextProposal" ||
-    proposalType === "/cosmos.gov.v1.MsgExecLegacyContent" || proposalType === "") {
-    type = "textProposal";
+  if (
+    proposalType === '/cosmos.gov.v1beta1.TextProposal' || proposalType === '/cosmos.gov.v1.MsgExecLegacyContent' || proposalType === ''
+  ) {
+    type = 'textProposal';
   }
 
   if (
-    proposalType === "/cosmos.params.v1beta1.ParameterChangeProposal" ||
-    proposalType.endsWith(".MsgUpdateParams")
+    proposalType === '/cosmos.params.v1beta1.ParameterChangeProposal' || proposalType.endsWith('.MsgUpdateParams')
   ) {
-    type = "parameterChangeProposal";
+    type = 'parameterChangeProposal';
   }
 
   if (
-    proposalType === "/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal" ||
-    proposalType.endsWith(".MsgSoftwareUpgrade")
+    proposalType === '/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal' || proposalType.endsWith('.MsgSoftwareUpgrade')
   ) {
-    type = "softwareUpgradeProposal";
+    type = 'softwareUpgradeProposal';
   }
 
   if (
-    proposalType === "/cosmos.upgrade.v1beta1.CommunityPoolSpendProposal" ||
-    proposalType.endsWith(".MsgCommunityPoolSpend")
+    proposalType === '/cosmos.upgrade.v1beta1.CommunityPoolSpendProposal' || proposalType.endsWith('.MsgCommunityPoolSpend')
   ) {
-    type = "communityPoolSpendProposal";
+    type = 'communityPoolSpendProposal';
   }
 
-  if (proposalType.endsWith(".MsgExec")) {
-    type = "msgExec";
+  if (proposalType.endsWith('.MsgExec')) {
+    type = 'authzExec';
   }
 
   return type;
 };
 
 const KNOWN_TYPES = [
-  "textProposal",
-  "parameterChangeProposal",
-  "softwareUpgradeProposal",
-  "communityPoolSpendProposal",
-  "multiple",
+  'textProposal',
+  'parameterChangeProposal',
+  'softwareUpgradeProposal',
+  'communityPoolSpendProposal',
+  'multiple',
+  'authzExec',
 ];
 
 /**
@@ -50,11 +49,11 @@ const KNOWN_TYPES = [
 export const getProposalDisplayTypes = (rawContent: unknown): string[] => {
   const contentArray = Array.isArray(rawContent) ? rawContent : [rawContent];
   const types = contentArray
-    .filter((c): c is Record<string, unknown> => typeof c === "object" && c !== null)
-    .map((c) => getProposalType(R.pathOr("", ["@type"], c) as string));
+    .filter((c): c is Record<string, unknown> => typeof c === 'object' && c !== null)
+    .map((c) => getProposalType(R.pathOr('', ['@type'], c) as string));
   const uniqueTypes = [...new Set(types.filter(Boolean))];
-  if (uniqueTypes.length === 0) return ["textProposal"];
-  return uniqueTypes.map((t) => (KNOWN_TYPES.includes(t) ? t : "other"));
+  if (uniqueTypes.length === 0) return ['textProposal'];
+  return uniqueTypes.map((t) => (KNOWN_TYPES.includes(t) ? t : 'other'));
 };
 
 /**
@@ -62,14 +61,13 @@ export const getProposalDisplayTypes = (rawContent: unknown): string[] => {
  */
 export const getProposalDisplayType = (rawContent: unknown): string => {
   const types = getProposalDisplayTypes(rawContent);
-  if (types.length <= 1) return types[0] ?? "textProposal";
-  return "multiple";
+  if (types.length <= 1) return types[0] ?? 'textProposal';
+  return 'multiple';
 };
 
-export const shouldShowData = (status: string) =>
-  [
-    "PROPOSAL_STATUS_VOTING_PERIOD",
-    "PROPOSAL_STATUS_PASSED",
-    "PROPOSAL_STATUS_REJECTED",
-    "PROPOSAL_STATUS_FAILED",
-  ].includes(status);
+export const shouldShowData = (status: string) => [
+  'PROPOSAL_STATUS_VOTING_PERIOD',
+  'PROPOSAL_STATUS_PASSED',
+  'PROPOSAL_STATUS_REJECTED',
+  'PROPOSAL_STATUS_FAILED',
+].includes(status);


### PR DESCRIPTION
## Summary
- Refactor Proposal Detail Overview into metadata/messages sections with collapsible message grouping UI
- Add auto-matched nested message type tags to AuthzExec proposal headers (color/label)
- Support new transaction types: CancelUndelegate, CancelProposal, CosmwasmInstantiateContract2, CosmwasmUpdateLabel
- Fix bugs: R.pathOr path argument, Messages label styling, empty content TextProposal handling
- Migrate to Yarn Berry and clean up build configuration

## Changes
- **Proposal Overview refactor**: Split into metadata + collapsible messages section layout
- **AuthzExec tag system**: Lightweight type-to-tag auto-mapping via `tag_map.ts`
- **New message components**: CancelUndelegate, CancelProposal, InstantiateContract2, UpdateLabel
- **Bug fixes**: `R.pathOr` path argument, Messages label font color, legacy tx event handling
- **Build**: Yarn Berry migration, webpack optimization

## Test
- [ ] Verify each proposal type (ParamsChange, AuthzExec, etc.) renders correctly on proposal detail page
- [ ] Confirm AuthzExec proposal header displays nested message tags with correct colors and labels
- [ ] Check new transaction types (CancelUndelegate, CancelProposal, etc.) in transaction list and detail views
- [ ] Verify proposals list page UI works as expected

### Test Screenshot
<img width="1814" height="596" alt="image" src="https://github.com/user-attachments/assets/3c84f37f-9185-45bf-963d-87aca2b7bf2e" />
